### PR TITLE
I18n

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { IntlProvider } from 'react-intl';
+import {IntlProvider, useIntl} from 'react-intl';
 import '../styles/index.css'
 import { makeTheme } from '../src/designSystem/theme/theme'
 import enMessages from '../src/translations/shared.en.json'
-import {DesignSystemProvider} from "../src/designSystem/DesignSystemProvider";
+import { DesignSystemProvider } from "../src/designSystem/DesignSystemProvider";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -40,14 +40,23 @@ const themeOverwrite = {
 }
 
 export const decorators = [
-  (Story) => (
-    <DesignSystemProvider theme={makeTheme(themeOverwrite)}>
-      <IntlProvider
-        locale="en"
-        messages={enMessages}
-      >
+  (Story) => {
+    const intl = useIntl()
+    const internationalization = {
+      translate: (key, values) => intl.formatMessage({id: key}, values)
+    }
+    return (
+      <DesignSystemProvider theme={makeTheme(themeOverwrite)} internationalization={internationalization}>
         <Story />
-      </IntlProvider>
-    </DesignSystemProvider>
-  ),
+      </DesignSystemProvider>
+    )
+  },
+  (Story) => (
+    <IntlProvider
+      locale="en"
+      messages={enMessages}
+    >
+      <Story />
+    </IntlProvider>
+  )
 ];

--- a/src/components/button/SubmitButton.tsx
+++ b/src/components/button/SubmitButton.tsx
@@ -1,18 +1,10 @@
 import { useFormikContext } from 'formik'
-import { FormattedMessage } from 'react-intl'
 
 import React from 'react'
 import { Button, ButtonProps } from './Button'
 
 const SubmitButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      children = <FormattedMessage id="shared.save" />,
-      disabled = false,
-      ...props
-    },
-    ref
-  ) => {
+  ({ children, disabled = false, ...props }, ref) => {
     const formik = useFormikContext()
 
     return (

--- a/src/components/header/HeaderBackWithEdit.tsx
+++ b/src/components/header/HeaderBackWithEdit.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from 'react'
 import { useRouter } from '../../designSystem/router/RouterContext'
 import { HeaderArea } from './areas/HeaderArea'
 import { HeaderBackAction } from './actions/HeaderBackAction'
@@ -21,24 +22,30 @@ type Props = {
    * Override default onBack action.
    */
   onBack?: () => void
+
+  /**
+   * Override default accessibility label for back action.
+   */
+  backLabel?: string
 }
 
-const HeaderBackWithEdit: React.FC<Props> = ({
+export function HeaderBackWithEdit({
   title,
   editHref,
   editLabel,
   onBack,
-}) => {
+  backLabel,
+}: Props): ReactElement {
   const router = useRouter()
 
   return (
     <HeaderArea
-      navigation={<HeaderBackAction onClick={onBack || router.back} />}
+      navigation={
+        <HeaderBackAction onClick={onBack || router.back} label={backLabel} />
+      }
     >
       <HeaderTitle>{title}</HeaderTitle>
       <HeaderEditAction href={editHref} label={editLabel} />
     </HeaderArea>
   )
 }
-
-export { HeaderBackWithEdit }

--- a/src/components/header/HeaderCloseWithSearch.stories.mdx
+++ b/src/components/header/HeaderCloseWithSearch.stories.mdx
@@ -41,3 +41,7 @@ export const Template = ({ ...args }) => {
 ### Theme
 
 The variants are the same as for the [HeaderMainWithSearch](http://localhost:4000/?path=/docs/components-header-headermainwithsearch--default-story#theme).
+
+### Internationalization
+
+- `shared.search.close`

--- a/src/components/header/HeaderCloseWithSearch.tsx
+++ b/src/components/header/HeaderCloseWithSearch.tsx
@@ -1,6 +1,5 @@
 import IconSearch from '@aboutbits/react-material-icons/dist/IconSearch'
 import React, { ReactNode, useState } from 'react'
-import { useIntl } from 'react-intl'
 import IconClose from '@aboutbits/react-material-icons/dist/IconClose'
 import {
   HeaderArea,
@@ -10,6 +9,7 @@ import {
   HeaderLeftArea,
 } from '../header'
 import { UseSearchQuery } from '../types'
+import { useInternationalization } from '../../designSystem/internationalization/InternationalizationContext'
 import { HeaderLargeAction } from './actions/HeaderLargeAction'
 import { HeaderSearch } from './HeaderSearch'
 import { Props as HeaderMainProps } from './HeaderMain'
@@ -68,7 +68,7 @@ const HeaderNotSearching: React.FC<{
   startSearch: () => void
   onClose: () => void
 }> = ({ title, labelIcon, startSearch, onClose }) => {
-  const intl = useIntl()
+  const internationalization = useInternationalization()
 
   return (
     <HeaderArea
@@ -76,7 +76,7 @@ const HeaderNotSearching: React.FC<{
         <HeaderLeftArea>
           <HeaderLargeAction
             icon={IconClose}
-            label={intl.formatMessage({ id: 'shared.search.close' })}
+            label={internationalization.translate('shared.search.close')}
             onClick={onClose}
           />
         </HeaderLeftArea>

--- a/src/components/header/HeaderSearch.stories.mdx
+++ b/src/components/header/HeaderSearch.stories.mdx
@@ -45,7 +45,7 @@ export const Template = ({ ...args }) => {
 - `header.search.clearButton.normal`: Define the hover and focus interaction for the button.
 - `header.search.icon.base`: Define the default width and height of the icon.
 
-### React Intl
+### Internationalization
 
 - `shared.search.placeholder`: Placeholder text for search field
 - `shared.search.clear`: Accessibility label for clear button in the search field

--- a/src/components/header/HeaderSearch.tsx
+++ b/src/components/header/HeaderSearch.tsx
@@ -1,9 +1,9 @@
-import { useIntl } from 'react-intl'
 import { useEffect, useRef } from 'react'
 import IconArrowBack from '@aboutbits/react-material-icons/dist/IconArrowBack'
 import classNames from 'classnames'
 import IconClose from '@aboutbits/react-material-icons/dist/IconClose'
 import { useTheme } from '../../designSystem/theme/ThemeContext'
+import { useInternationalization } from '../../designSystem/internationalization/InternationalizationContext'
 import { HeaderArea } from './areas/HeaderArea'
 import { HeaderLeftArea } from './areas/HeaderLeftArea'
 import { HeaderLargeAction } from './actions/HeaderLargeAction'
@@ -35,7 +35,7 @@ const HeaderSearch: React.FC<Props> = ({
   stopSearch,
   clearSearch,
 }) => {
-  const intl = useIntl()
+  const internationalization = useInternationalization()
   const searchInput = useRef<HTMLInputElement>(null)
   const { header } = useTheme()
 
@@ -51,7 +51,7 @@ const HeaderSearch: React.FC<Props> = ({
         <HeaderLeftArea className="lg:hidden">
           <HeaderLargeAction
             icon={IconArrowBack}
-            label={intl.formatMessage({ id: 'shared.search.back' })}
+            label={internationalization.translate('shared.search.back')}
             onClick={stopSearch}
           />
         </HeaderLeftArea>
@@ -64,9 +64,9 @@ const HeaderSearch: React.FC<Props> = ({
           onChange={(ev: React.ChangeEvent<HTMLInputElement>): void =>
             setText(ev.target.value)
           }
-          placeholder={intl.formatMessage({
-            id: 'shared.search.placeholder',
-          })}
+          placeholder={internationalization.translate(
+            'shared.search.placeholder'
+          )}
           className={classNames(
             header.search.input.base,
             header.search.input.normal
@@ -77,9 +77,7 @@ const HeaderSearch: React.FC<Props> = ({
             header.search.clearButton.base,
             header.search.clearButton.normal
           )}
-          aria-label={intl.formatMessage({
-            id: 'shared.search.clear',
-          })}
+          aria-label={internationalization.translate('shared.search.clear')}
           onClick={clearSearch}
         >
           <IconClose className={header.search.icon.base} />
@@ -88,9 +86,7 @@ const HeaderSearch: React.FC<Props> = ({
       <HeaderRightArea className="hidden lg:block">
         <HeaderSmallAction
           icon={IconClose}
-          label={intl.formatMessage({
-            id: 'shared.search.back',
-          })}
+          label={internationalization.translate('shared.search.back')}
           onClick={stopSearch}
         />
       </HeaderRightArea>

--- a/src/components/header/actions/HeaderBackAction.stories.mdx
+++ b/src/components/header/actions/HeaderBackAction.stories.mdx
@@ -28,6 +28,6 @@ export const Template = ({ ...args }) => (
 
 <ArgsTable story="Default" />
 
-### React Intl
+### Internationalization
 
 - `shared.button.goBack`: Accessibility label for arrow back icon

--- a/src/components/header/actions/HeaderBackAction.tsx
+++ b/src/components/header/actions/HeaderBackAction.tsx
@@ -1,12 +1,12 @@
-import React, { ComponentType } from 'react'
+import React, { ComponentType, ReactElement } from 'react'
 import IconArrowBack from '@aboutbits/react-material-icons/dist/IconArrowBack'
 import { IconProps } from '@aboutbits/react-material-icons/dist/types'
-import { useIntl } from 'react-intl'
 import { HeaderLargeAction } from '../index'
 import { HeaderLeftArea } from '../areas/HeaderLeftArea'
 import { ClassNameProps } from '../../types'
+import { useInternationalization } from '../../../designSystem/internationalization/InternationalizationContext'
 
-type Props = ClassNameProps & {
+export type Props = ClassNameProps & {
   /**
    * Defines the icon of the button.
    * */
@@ -21,24 +21,22 @@ type Props = ClassNameProps & {
   onClick: () => void
 }
 
-const HeaderBackAction: React.FC<Props> = ({
+export function HeaderBackAction({
   label,
   onClick,
   icon = IconArrowBack,
   className,
-}) => {
-  const intl = useIntl()
+}: Props): ReactElement {
+  const internationalization = useInternationalization()
 
   return (
     <HeaderLeftArea>
       <HeaderLargeAction
         icon={icon}
-        label={label || intl.formatMessage({ id: 'shared.button.goBack' })}
+        label={label || internationalization.translate('shared.button.goBack')}
         onClick={onClick}
         className={className}
       />
     </HeaderLeftArea>
   )
 }
-
-export { HeaderBackAction }

--- a/src/components/header/actions/HeaderLargeAction.stories.mdx
+++ b/src/components/header/actions/HeaderLargeAction.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 import Icon from '@aboutbits/react-material-icons/dist/IconSearch'
 import IconEdit from '@aboutbits/react-material-icons/dist/IconEdit'
-import { actions } from '@storybook/addon-actions'
+import { action } from '@storybook/addon-actions'
 import { HeaderLargeAction } from './HeaderLargeAction'
 
 <Meta
@@ -17,7 +17,7 @@ export const Template = ({ ...args }) => (
   <HeaderLargeAction
     {...args}
     icon={Icon}
-    onClick={actions('clicked')}
+    onClick={action('onClick')}
     label="Enter search term"
   />
 )

--- a/src/components/header/actions/HeaderSmallAction.stories.mdx
+++ b/src/components/header/actions/HeaderSmallAction.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 import Icon from '@aboutbits/react-material-icons/dist/IconSearch'
 import IconEdit from '@aboutbits/react-material-icons/dist/IconEdit'
-import { actions } from '@storybook/addon-actions'
+import { action } from '@storybook/addon-actions'
 import { HeaderSmallAction } from './HeaderSmallAction'
 
 <Meta
@@ -17,7 +17,7 @@ export const Template = ({ ...args }) => (
   <HeaderSmallAction
     {...args}
     icon={Icon}
-    onClick={actions('clicked')}
+    onClick={action('onClick')}
     label="Enter search term"
   />
 )

--- a/src/components/header/actions/HeaderSmallAction.stories.mdx
+++ b/src/components/header/actions/HeaderSmallAction.stories.mdx
@@ -39,6 +39,10 @@ export const Template = ({ ...args }) => (
 
 <Canvas>
   <Story name="Custom Icon">
-    <HeaderSmallAction icon={IconEdit} label="Edit" />
+    <HeaderSmallAction
+      icon={IconEdit}
+      label="Edit"
+      onClick={action('onClick')}
+    />
   </Story>
 </Canvas>

--- a/src/components/header/areas/HeaderArea.stories.mdx
+++ b/src/components/header/areas/HeaderArea.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 import IconArrowBack from '@aboutbits/react-material-icons/dist/IconArrowBack'
-import { actions } from '@storybook/addon-actions'
+import { action, actions } from '@storybook/addon-actions'
 import { HeaderBackAction } from '../actions/HeaderBackAction'
 import { HeaderArea } from './HeaderArea'
 import { MenuProvider } from './MenuContext'
@@ -42,7 +42,7 @@ export const Template = ({ ...args }) => (
 - `header.area.base`: Define the padding and the centering of the header area.
 - `header.area.normal`: Defines the background of the header area.
 
-### React Intl
+### Internationalization
 
 - `app.nav.menu`: Accessibility label for burger menu
 
@@ -53,7 +53,11 @@ export const Template = ({ ...args }) => (
     <MenuProvider>
       <HeaderArea
         navigation={
-          <HeaderBackAction icon={IconArrowBack} label="Go to previous page" />
+          <HeaderBackAction
+            icon={IconArrowBack}
+            label="Go to previous page"
+            onClick={action('onClick')}
+          />
         }
       >
         <HeaderTitle>Header Title</HeaderTitle>

--- a/src/components/header/areas/HeaderArea.tsx
+++ b/src/components/header/areas/HeaderArea.tsx
@@ -1,10 +1,9 @@
 import React, { ReactNode } from 'react'
-import { useIntl } from 'react-intl'
 import IconMenu from '@aboutbits/react-material-icons/dist/IconMenu'
-// original path: ../../../layouts/app/menu/MenuContext
 import classNames from 'classnames'
 import { HeaderLargeAction } from '../actions/HeaderLargeAction'
 import { useTheme } from '../../../designSystem/theme/ThemeContext'
+import { useInternationalization } from '../../../designSystem/internationalization/InternationalizationContext'
 import { useMenuToggle } from './MenuContext'
 import { HeaderLeftArea } from './HeaderLeftArea'
 
@@ -16,7 +15,7 @@ type Props = {
 }
 
 const HeaderArea: React.FC<Props> = ({ navigation = null, children }) => {
-  const intl = useIntl()
+  const intl = useInternationalization()
   const menuToggle = useMenuToggle()
   const { header } = useTheme()
   return (
@@ -25,7 +24,7 @@ const HeaderArea: React.FC<Props> = ({ navigation = null, children }) => {
         <HeaderLeftArea className="block lg:hidden">
           <HeaderLargeAction
             icon={IconMenu}
-            label={intl.formatMessage({ id: 'app.nav.menu' })}
+            label={intl.translate('app.nav.menu')}
             onClick={menuToggle}
           />
         </HeaderLeftArea>

--- a/src/components/pagination/PaginationInMemory.stories.mdx
+++ b/src/components/pagination/PaginationInMemory.stories.mdx
@@ -51,7 +51,7 @@ export const Template = ({ children, ...args }) => {
 - `pagination.page.disabled`
 - `pagination.page.current`
 
-### React Intl
+### Internationalization
 
 - `shared.pagination.page`: Accessibility label for the page counter.
 - `shared.pagination.prev`: Accessibility label for previous page.

--- a/src/components/pagination/PaginationInMemory.tsx
+++ b/src/components/pagination/PaginationInMemory.tsx
@@ -1,8 +1,8 @@
-import { useIntl } from 'react-intl'
 import classNames from 'classnames'
 import { calculatePagination, IndexType } from '@aboutbits/pagination'
 import { useTheme } from '../../designSystem/theme/ThemeContext'
 import { ClassNameProps } from '../types'
+import { useInternationalization } from '../../designSystem/internationalization/InternationalizationContext'
 import { PaginationContainer } from './PaginationContainer'
 import {
   PaginationNextContent,
@@ -80,7 +80,7 @@ const PaginationInMemory: React.FC<Props> = ({
   config,
   className,
 }) => {
-  const intl = useIntl()
+  const internationalization = useInternationalization()
   const { pagination: paginationTheme } = useTheme()
   const pagination = calculatePagination(page, size, total, config)
 
@@ -89,7 +89,7 @@ const PaginationInMemory: React.FC<Props> = ({
   return (
     <PaginationContainer className={className}>
       <SectionPaginationInMemoryButton
-        aria-label={intl.formatMessage({ id: 'shared.pagination.prev' })}
+        aria-label={internationalization.translate('shared.pagination.prev')}
         disabled={pagination.previous.isDisabled}
         onChangePage={onChangePage}
         pageIndex={pagination.previous.indexNumber}
@@ -103,8 +103,8 @@ const PaginationInMemory: React.FC<Props> = ({
             <PaginationPagesListItem key={page.indexNumber}>
               <SectionPaginationInMemoryButton
                 aria-current={page.isCurrent ? 'page' : false}
-                aria-label={intl.formatMessage(
-                  { id: 'shared.pagination.page' },
+                aria-label={internationalization.translate(
+                  'shared.pagination.page',
                   { page: page.displayNumber }
                 )}
                 className={classNames(
@@ -123,7 +123,7 @@ const PaginationInMemory: React.FC<Props> = ({
       </PaginationPagesList>
 
       <SectionPaginationInMemoryButton
-        aria-label={intl.formatMessage({ id: 'shared.pagination.next' })}
+        aria-label={internationalization.translate('shared.pagination.next')}
         disabled={pagination.next.isDisabled}
         onChangePage={onChangePage}
         pageIndex={pagination.next.indexNumber}

--- a/src/components/pagination/PaginationNextContent.stories.mdx
+++ b/src/components/pagination/PaginationNextContent.stories.mdx
@@ -20,6 +20,6 @@ export const Template = ({ ...args }) => <PaginationNextContent {...args} />
 
 - `pagination.nextContent.icon.base`: Define the inline-block, width and height of the component.
 
-### React Intl
+### Internationalization
 
 - `shared.pagination.next`: Define the description text for the arrow next.

--- a/src/components/pagination/PaginationPreviousContent.stories.mdx
+++ b/src/components/pagination/PaginationPreviousContent.stories.mdx
@@ -20,6 +20,6 @@ export const Template = ({ ...args }) => <PaginationPreviousContent {...args} />
 
 - `pagination.previousContent.base`: Define the inline-block, width and height of the component.
 
-### React Intl
+### Internationalization
 
 - `shared.pagination.prev`: Define the description text for the arrow back.

--- a/src/components/pagination/PaginationPreviousNextContent.tsx
+++ b/src/components/pagination/PaginationPreviousNextContent.tsx
@@ -1,17 +1,18 @@
 import { ReactElement } from 'react'
-import { FormattedMessage } from 'react-intl'
 import IconKeyboardArrowRight from '@aboutbits/react-material-icons/dist/IconKeyboardArrowRight'
 import IconKeyboardArrowLeft from '@aboutbits/react-material-icons/dist/IconKeyboardArrowLeft'
 import { useTheme } from '../../designSystem/theme/ThemeContext'
+import { useInternationalization } from '../../designSystem/internationalization/InternationalizationContext'
 
 export function PaginationPreviousContent(): ReactElement {
   const { pagination } = useTheme()
+  const internationalization = useInternationalization()
 
   return (
     <>
       <IconKeyboardArrowLeft className={pagination.prevNext.icon.base} />
       <span className={pagination.prevNext.text.base}>
-        <FormattedMessage id="shared.pagination.prev" />
+        {internationalization.translate('shared.pagination.prev')}
       </span>
     </>
   )
@@ -19,11 +20,12 @@ export function PaginationPreviousContent(): ReactElement {
 
 export function PaginationNextContent(): ReactElement {
   const { pagination } = useTheme()
+  const internationalization = useInternationalization()
 
   return (
     <>
       <span className={pagination.prevNext.text.base}>
-        <FormattedMessage id="shared.pagination.next" />
+        {internationalization.translate('shared.pagination.next')}
       </span>
       <IconKeyboardArrowRight className={pagination.prevNext.icon.base} />
     </>

--- a/src/components/pagination/PaginationRouter.stories.mdx
+++ b/src/components/pagination/PaginationRouter.stories.mdx
@@ -57,7 +57,7 @@ export const Template = ({ children, ...args }) => {
 - `pagination.page.disabled`
 - `pagination.page.current`
 
-### React Intl
+### Internationalization
 
 - `shared.pagination.page`: Accessibility label for the page counter.
 - `shared.pagination.prev`: Accessibility label for previous page.

--- a/src/components/pagination/PaginationRouter.tsx
+++ b/src/components/pagination/PaginationRouter.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames'
 import { calculatePagination, IndexType } from '@aboutbits/pagination'
-import { useIntl } from 'react-intl'
 import { useLinkComponent } from '../../designSystem/router/LinkComponentContext'
 import { useTheme } from '../../designSystem/theme/ThemeContext'
 import { ClassNameProps } from '../types'
+import { useInternationalization } from '../../designSystem/internationalization/InternationalizationContext'
 import { PaginationContainer } from './PaginationContainer'
 import {
   PaginationNextContent,
@@ -53,7 +53,7 @@ const PaginationRouter: React.FC<Props> = ({
   config,
   className,
 }) => {
-  const intl = useIntl()
+  const internationalization = useInternationalization()
 
   const LinkComponent = useLinkComponent()
   const { pagination: paginationTheme } = useTheme()
@@ -66,7 +66,7 @@ const PaginationRouter: React.FC<Props> = ({
     <PaginationContainer className={className}>
       <LinkComponent
         {...linkProps({ pageIndex: pagination.previous.indexNumber, size })}
-        aria-label={intl.formatMessage({ id: 'shared.pagination.prev' })}
+        aria-label={internationalization.translate('shared.pagination.prev')}
         aria-disabled={pagination.previous.isDisabled}
         role="previous-link"
         className={classNames(
@@ -89,8 +89,8 @@ const PaginationRouter: React.FC<Props> = ({
                   size,
                 })}
                 aria-current={page.isCurrent ? 'page' : false}
-                aria-label={intl.formatMessage(
-                  { id: 'shared.pagination.page' },
+                aria-label={internationalization.translate(
+                  'shared.pagination.page',
                   { page: page.displayNumber }
                 )}
                 className={classNames(
@@ -112,7 +112,7 @@ const PaginationRouter: React.FC<Props> = ({
           pageIndex: pagination.next.indexNumber,
           size,
         })}
-        aria-label={intl.formatMessage({ id: 'shared.pagination.next' })}
+        aria-label={internationalization.translate('shared.pagination.next')}
         aria-disabled={pagination.next.isDisabled}
         role="next-link"
         className={classNames(

--- a/src/components/section/SectionError/SectionError.stories.mdx
+++ b/src/components/section/SectionError/SectionError.stories.mdx
@@ -10,11 +10,6 @@ import { SectionError } from './SectionError'
 This component renders an error with a reload page button.
 This is very useful if your page has only one section.
 
-The component makes use of `react-intl` to translate the following message ids:
-
-- `shared.error.title`
-- `shared.button.reload`
-
 export const Template = ({ children }) => (
   <SectionError icon={<Warning />}>{children}</SectionError>
 )
@@ -40,3 +35,8 @@ export const Template = ({ children }) => (
 - `section.error.icon.base`: Define the style of the icon.
 - `section.error.title.base`: Define the style of the title.
 - `section.error.children.base`: Define the style of the passed children.
+
+### Internationalization
+
+- `shared.error.title`
+- `shared.button.reload`

--- a/src/components/section/SectionError/SectionError.tsx
+++ b/src/components/section/SectionError/SectionError.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react'
-import { FormattedMessage } from 'react-intl'
 
 import { Button } from '../../button/Button'
 import { useTheme } from '../../../designSystem/theme/ThemeContext'
+import { useInternationalization } from '../../../designSystem/internationalization/InternationalizationContext'
 
 type Props = {
   /**
@@ -11,22 +11,22 @@ type Props = {
   icon: ReactNode
 }
 
-const SectionError: React.FC<Props> = ({ icon, children }) => {
+export const SectionError: React.FC<Props> = ({ icon, children }) => {
   const { section } = useTheme()
+  const internationalization = useInternationalization()
   return (
     <div className={section.error.base}>
       <div className={section.error.icon.base}>{icon}</div>
       <div className={section.error.title.base}>
-        <FormattedMessage id="shared.error.title" />
+        {internationalization.translate('shared.error.title')}
       </div>
       <div className={section.error.children.base}>{children}</div>
       <Button
         onClick={() => window.location.reload()}
         className={section.error.button.base}
       >
-        <FormattedMessage id="shared.button.reload" />
+        {internationalization.translate('shared.button.reload')}
       </Button>
     </div>
   )
 }
-export { SectionError }

--- a/src/designSystem/DesignSystemProvider.tsx
+++ b/src/designSystem/DesignSystemProvider.tsx
@@ -6,31 +6,43 @@ import {
   LinkComponentContext,
 } from './router/LinkComponentContext'
 import { RouterContext, Router, useRouter } from './router/RouterContext'
+import {
+  Internationalization,
+  InternationalizationContext,
+  useInternationalization,
+} from './internationalization/InternationalizationContext'
 
 type Props = {
   theme: Theme
   linkComponent?: LinkComponent
   router?: Router
+  internationalization?: Internationalization
 }
 
 export const DesignSystemProvider: React.FC<Props> = ({
   theme,
   linkComponent,
   router,
+  internationalization,
   children,
 }) => {
   const linkComponentFromContext = useContext(LinkComponentContext)
   const routerComponentFromContext = useRouter()
+  const internationalizationFromContext = useInternationalization()
 
   return (
     <ThemeContext.Provider value={theme}>
-      <RouterContext.Provider value={router || routerComponentFromContext}>
-        <LinkComponentContext.Provider
-          value={linkComponent || linkComponentFromContext}
-        >
-          {children}
-        </LinkComponentContext.Provider>
-      </RouterContext.Provider>
+      <InternationalizationContext.Provider
+        value={internationalization || internationalizationFromContext}
+      >
+        <RouterContext.Provider value={router || routerComponentFromContext}>
+          <LinkComponentContext.Provider
+            value={linkComponent || linkComponentFromContext}
+          >
+            {children}
+          </LinkComponentContext.Provider>
+        </RouterContext.Provider>
+      </InternationalizationContext.Provider>
     </ThemeContext.Provider>
   )
 }

--- a/src/designSystem/internationalization/InternationalizationContext.tsx
+++ b/src/designSystem/internationalization/InternationalizationContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react'
+
+export type Internationalization = {
+  translate: (key: string, values?: unknown) => string
+}
+
+const defaultInternationalization: Internationalization = {
+  translate: (key) => key,
+}
+
+export const InternationalizationContext = createContext<Internationalization>(
+  defaultInternationalization
+)
+
+export function useInternationalization(): Internationalization {
+  return useContext(InternationalizationContext)
+}


### PR DESCRIPTION
Removal of dependency on `react-intl`

Instead of having a hard dependency on `react-intl`, we allow the user to specify a translation function in the `DesignSystemProvider`.