### PR TITLE
Refactoring of SelectItem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@aboutbits/internationalization": "^0.2.1",
         "@aboutbits/pagination": "^1.1.0",
         "@aboutbits/react-material-icons": "^1.0.1",
+        "@aboutbits/react-pagination": "^0.0.10",
         "@aboutbits/react-toolbox": "^0.1.2",
         "@babel/core": "^7.14.6",
         "@reach/dialog": "^0.16.0",
@@ -83,6 +84,15 @@
       "peerDependencies": {
         "react": "^16.8.0 || 17.x",
         "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@aboutbits/react-pagination": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@aboutbits/react-pagination/-/react-pagination-0.0.10.tgz",
+      "integrity": "sha512-VMKeeX3q2tgQyGN+K7ivJVd9LQ5ufnuxNkD0Gqz+SfC//gJr6YT01Q7QQVEzstEdkAXSYuQRgqlyuQCQxU6jkA==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@aboutbits/react-toolbox": {
@@ -28446,6 +28456,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@aboutbits/react-material-icons/-/react-material-icons-1.0.1.tgz",
       "integrity": "sha512-BuJu8F4SyMu7Tit0uWaWFxy0oQTL8Q+WU3grqBeifqgGmNj4SdzNm6r0BY/Bq1H5IQrpuHIdDghACkH6FnP3gw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@aboutbits/react-pagination": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@aboutbits/react-pagination/-/react-pagination-0.0.10.tgz",
+      "integrity": "sha512-VMKeeX3q2tgQyGN+K7ivJVd9LQ5ufnuxNkD0Gqz+SfC//gJr6YT01Q7QQVEzstEdkAXSYuQRgqlyuQCQxU6jkA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@aboutbits/internationalization": "^0.2.1",
     "@aboutbits/pagination": "^1.1.0",
     "@aboutbits/react-material-icons": "^1.0.1",
+    "@aboutbits/react-pagination": "^0.0.10",
     "@aboutbits/react-toolbox": "^0.1.2",
     "@babel/core": "^7.14.6",
     "@reach/dialog": "^0.16.0",

--- a/src/components/form/async/SelectItem.stories.mdx
+++ b/src/components/form/async/SelectItem.stories.mdx
@@ -18,11 +18,11 @@ import {
   decorators={[
     (Story) => {
       const validationSchema = Yup.object().shape({
-        user: Yup.string().required('Required'),
+        userId: Yup.string().required('Required'),
       })
       return (
         <Formik
-          initialValues={{ user: '' }}
+          initialValues={{ userId: '3' }}
           validateOnChange={true}
           validationSchema={validationSchema}
           onSubmit={(values) => action('onSubmit')(values)}
@@ -52,14 +52,14 @@ npm install @aboutbits/react-toolbox
   <Story
     name="Default"
     args={{
-      id: 'user',
-      name: 'user',
+      id: 'userId',
+      name: 'userId',
       label: 'SelectUser',
       placeholder: 'User',
-      defaultValue: { id: 0, name: '' },
       dialogTitle: 'Users',
       dialogLabel: 'Users',
       noSearchResults: 'No users available.',
+      extractIdFromItem: (item) => item.id,
       renderListItem: (item) => item.name,
       renderErrorMessage: (error) => error.message,
       paginationConfig: { indexType: IndexType.ZERO_BASED },
@@ -80,13 +80,34 @@ For customization of the styles please checkout the [theme section](/docs/compon
 
 <Canvas>
   <Story
-    name="Error"
+    name="With initial item"
     args={{
-      id: 'user',
-      name: 'user',
+      id: 'userId',
+      name: 'userId',
       label: 'SelectUser',
       placeholder: 'User',
-      defaultValue: { id: 0, name: '' },
+      initialItem: { id: 3, name: 'User 3' },
+      extractIdFromItem: (item) => item.id,
+      dialogTitle: 'Users',
+      dialogLabel: 'Users',
+      noSearchResults: 'No users available.',
+      renderListItem: (item) => item.name,
+      renderErrorMessage: (error) => error.message,
+      paginationConfig: { indexType: IndexType.ZERO_BASED },
+    }}
+  >
+    {TemplateNormal.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Error"
+    args={{
+      id: 'userId',
+      name: 'userId',
+      label: 'SelectUser',
+      placeholder: 'User',
       dialogTitle: 'Users',
       dialogLabel: 'Users',
       noSearchResults: 'No users available.',
@@ -103,11 +124,10 @@ For customization of the styles please checkout the [theme section](/docs/compon
   <Story
     name="Empty list"
     args={{
-      id: 'user',
-      name: 'user',
+      id: 'userId',
+      name: 'userId',
       label: 'SelectUser',
       placeholder: 'User',
-      defaultValue: { id: 0, name: '' },
       dialogTitle: 'Users',
       dialogLabel: 'Users',
       noSearchResults: 'No users available.',

--- a/src/components/form/async/SelectItem.stories.mdx
+++ b/src/components/form/async/SelectItem.stories.mdx
@@ -45,7 +45,7 @@ The component can be conveniently used to create a reference to another object.
 It leverages on [SelectDialog](/docs/components-dialog-selectdialog--default-story) and the package `@aboutbits/react-toolbox`.
 
 ```
-npm install @aboutbits/react-toolbox
+npm install @aboutbits/react-toolbox @aboutbits/react-pagination
 ```
 
 <Canvas>

--- a/src/components/form/async/SelectItem.templates.tsx
+++ b/src/components/form/async/SelectItem.templates.tsx
@@ -12,7 +12,7 @@ type User = {
 }
 
 const useGetData = ({
-  query,
+  search,
   page,
   size,
 }: SearchQueryParameters): {
@@ -33,15 +33,15 @@ const useGetData = ({
             }
           })
           .filter((user) => {
-            if (query) {
-              return user.name.includes(query)
+            if (search) {
+              return user.name.includes(search)
             } else {
               return true
             }
           })
       )
     }, 1000)
-  }, [query, page, size])
+  }, [search, page, size])
 
   if (data === undefined) {
     return {}

--- a/src/components/form/async/SelectItem.tsx
+++ b/src/components/form/async/SelectItem.tsx
@@ -21,11 +21,25 @@ import {
 export type SelectItemProps<ItemType, Error> = {
   id: string
   name: string
+  /**
+   * The initialItem allows you to pass the component the lookup object on first render.
+   * Afterwards on changed selection the component will handle it by itself.
+   */
   initialItem?: ItemType
+  /**
+   * Specify what you want to render in the input, once a value has been selected.
+   * If nothing is specified it will try to render it the same way as the list item.
+   *
+   * If no lookup value is available, it will render the id.
+   */
   renderInputValue?: (item: ItemType) => ReactNode
   label: string
   placeholder: string
   disabled?: boolean
+  /**
+   * This function will be used to extract the id value from the selected item.
+   * @param item
+   */
   extractIdFromItem: (item: ItemType) => string
 } & Pick<
   DialogProps<ItemType, Error>,

--- a/src/components/form/async/SelectItemDialogWithSearch.tsx
+++ b/src/components/form/async/SelectItemDialogWithSearch.tsx
@@ -76,8 +76,6 @@ export function SelectItemDialogWithSearch<ItemType, Error>({
     ? internationalization.translate('shared.select.search.empty')
     : noSearchResults
 
-  console.log({ search: queryParameters.search })
-
   return (
     <SelectDialog
       isOpen={isOpen}


### PR DESCRIPTION
1. SelectItem takes now only the id/name of the input field
2. SelectItem allows you to add an initalItem to render a selected item before the first selection happened. Afterwards the component will keep a copy of the selected item. I would say, if you really want to do a lookup before, than do it in client code.

The rest stayed the same more or less.
