### PR TITLE
Add dark mode for button components

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,11 +6,11 @@ import enMessages from '../src/translations/shared.en.json'
 import '../styles/index.css'
 
 // Add custom button tone for demo purpose
-customTheme.button.variantTone.solid.purple =
+customTheme.button.modeVariantTone.light.solid.purple =
   'bg-purple-500 hover:bg-purple-600 text-white outline-purple-500'
-customTheme.button.variantTone.ghost.purple =
+customTheme.button.modeVariantTone.light.ghost.purple =
   'hover:bg-purple-50 focus:bg-purple-50 border-purple-500 focus:border-transparent text-purple-500 outline-purple-500'
-customTheme.button.variantTone.transparent.purple =
+customTheme.button.modeVariantTone.light.transparent.purple =
   'hover:bg-purple-50 text-purple-500 focus:outline-purple-500'
 
 export const parameters = {

--- a/src/components/button/Button.stories.mdx
+++ b/src/components/button/Button.stories.mdx
@@ -1,7 +1,7 @@
 import IconAdd from '@aboutbits/react-material-icons/dist/IconAdd'
 import IconInfo from '@aboutbits/react-material-icons/dist/IconInfo'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
-import { Tone } from '../types'
+import { Tone, Mode } from '../types'
 import { Size, Variant } from './types'
 import { Button } from './Button'
 
@@ -19,6 +19,7 @@ export const Template = ({ children, ...args }) => (
     args={{
       children: 'Default Button',
       disabled: false,
+      mode: Mode.light,
       variant: Variant.solid,
       size: Size.md,
       tone: Tone.primary,
@@ -26,6 +27,10 @@ export const Template = ({ children, ...args }) => (
       iconEnd: 'None',
     }}
     argTypes={{
+      mode: {
+        options: Object.values(Mode),
+        control: { type: 'radio' },
+      },
       variant: {
         options: Object.values(Variant),
         control: { type: 'radio' },
@@ -84,27 +89,22 @@ React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButto
 - `button.button.icon.iconEnd.size.sm`: Define the size of the small size end icon.
 - `button.button.icon.iconEnd.size.md`: Define the size of the medium size end icon.
 - `button.button.icon.iconEnd.size.lg`: Define the size of the large size end icon.
-- `button.variantTone.solid.primary`: Define the color and interactions for the button with the variant solid and tone primary.
-- `button.variantTone.solid.neutral`: Define the color and interactions for the button with the variant solid and tone neutral.
-- `button.variantTone.solid.warning`: Define the color and interactions for the button with the variant solid and tone warning.
-- `button.variantTone.solid.critical`: Define the color and interactions for the button with the variant solid and tone critical.
-- `button.variantTone.solid.success`: Define the color and interactions for the button with the variant solid and tone success.
-- `button.variantTone.solid.informative`: Define the color and interactions for the button with the variant solid and tone informative.
-- `button.variantTone.solid.disabled`: Define the status disabled for the button with the variant solid.
-- `button.variantTone.ghost.primary`: Define the color and interactions for the button with the variant ghost and tone primary.
-- `button.variantTone.ghost.neutral`: Define the color and interactions for the button with the variant ghost and tone neutral.
-- `button.variantTone.ghost.warning`: Define the color and interactions for the button with the variant ghost and tone warning.
-- `button.variantTone.ghost.critical`: Define the color and interactions for the button with the variant ghost and tone critical.
-- `button.variantTone.ghost.success`: Define the color and interactions for the button with the variant ghost and tone success.
-- `button.variantTone.ghost.informative`: Define the color and interactions for the button with the variant ghost and tone informative.
-- `button.variantTone.ghost.disabled`: Define the status disabled for the button with the variant ghost.
-- `button.variantTone.transparent.primary`: Define the color and interactions for the button with the variant transparent and tone primary.
-- `button.variantTone.transparent.neutral`: Define the color and interactions for the button with the variant transparent and tone neutral.
-- `button.variantTone.transparent.warning`: Define the color and interactions for the button with the variant transparent and tone warning.
-- `button.variantTone.transparent.critical`: Define the color and interactions for the button with the variant transparent and tone critical.
-- `button.variantTone.transparent.success`: Define the color and interactions for the button with the variant transparent and tone success.
-- `button.variantTone.transparent.informative`: Define the color and interactions for the button with the variant transparent and tone informative.
-- `button.variantTone.transparent.disabled`: Define the status disabled for the button with the variant transparent.
+- `button.modeVariantTone[$mode][$variant][$tone]`: Define the color and interactions for the button with the given mode, variant and tone.
+
+## Mode
+
+The `Mode` determines if the component is placed on light or dark background.
+
+<Canvas>
+  <Story name="ModeLight">
+    <Button mode={Mode.light}>Button Light</Button>
+  </Story>
+  <Story name="ModeDark">
+    <div className="p-5 bg-neutral-700">
+      <Button mode={Mode.dark}>Button Dark</Button>
+    </div>
+  </Story>
+</Canvas>
 
 ## Variants
 
@@ -172,17 +172,19 @@ If the provided colors are not satisfying the needs of a project, it is possible
 ```js
 module.exports = {
   button: {
-    variantTone: {
-      solid: {
-        purple:
-          'bg-purple-500 hover:bg-purple-600 text-white outline-purple-500',
-      },
-      ghost: {
-        purple:
-          'hover:bg-purple-50 focus:bg-purple-50 border-purple-500 focus:border-transparent text-purple-500 outline-purple-500',
-      },
-      transparent: {
-        purple: 'hover:bg-purple-50 text-purple-500 focus:outline-purple-500',
+    modeVariantTone: {
+      light: {
+        solid: {
+          purple:
+            'bg-purple-500 hover:bg-purple-600 text-white outline-purple-500',
+        },
+        ghost: {
+          purple:
+            'hover:bg-purple-50 focus:bg-purple-50 border-purple-500 focus:border-transparent text-purple-500 outline-purple-500',
+        },
+        transparent: {
+          purple: 'hover:bg-purple-50 text-purple-500 focus:outline-purple-500',
+        },
       },
     },
   },

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React from 'react'
 import { useTheme } from '../../framework'
-import { Tone } from '../types'
+import { Mode, Tone } from '../types'
 import { ButtonCommonProps, ButtonStyleProps, Size, Variant } from './types'
 
 export type ButtonProps = React.DetailedHTMLProps<
@@ -14,6 +14,7 @@ export type ButtonProps = React.DetailedHTMLProps<
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
+      mode = Mode.light,
       variant = Variant.solid,
       size = Size.md,
       tone = Tone.primary,
@@ -34,8 +35,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           button.button.base,
           !props.disabled
             ? // @ts-ignore
-              button.variantTone[variant][tone]
-            : button.variantTone[variant].disabled,
+              button.modeVariantTone[mode][variant][tone]
+            : button.modeVariantTone[mode][variant].disabled,
           button.button.variantSize.base[size],
           // @ts-ignore
           button.button.variantSize[variant]?.[size],

--- a/src/components/button/ButtonIcon.stories.mdx
+++ b/src/components/button/ButtonIcon.stories.mdx
@@ -1,7 +1,7 @@
 import IconAdd from '@aboutbits/react-material-icons/dist/IconAdd'
 import IconInfo from '@aboutbits/react-material-icons/dist/IconInfo'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
-import { Tone } from '../types'
+import { Tone, Mode } from '../types'
 import { Size, Variant } from './types'
 import { ButtonIcon } from './ButtonIcon'
 
@@ -16,12 +16,17 @@ export const Template = ({ ...args }) => <ButtonIcon {...args} />
     name="Default"
     args={{
       disabled: false,
+      mode: Mode.light,
       variant: Variant.solid,
       size: Size.md,
       tone: Tone.primary,
       icon: 'Add',
     }}
     argTypes={{
+      mode: {
+        options: Object.values(Mode),
+        control: { type: 'radio' },
+      },
       variant: {
         options: Object.values(Variant),
         control: { type: 'radio' },
@@ -69,7 +74,22 @@ React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButto
 - `button.buttonIcon.variantSize.base.md`: Define the base styles for the medium size size button.
 - `button.buttonIcon.variantSize.base.lg`: Define the base styles for the large size size button.
 
-Additionally, all the `button.variantTone` themes are used. See [Button](/docs/components-button-button--default-story#theme).
+Additionally, all the `button.modeVariantTone` themes are used. See [Button](/docs/components-button-button--default-story#theme).
+
+## Mode
+
+The `Mode` determines if the component is placed on light or dark background.
+
+<Canvas>
+  <Story name="ModeLight">
+    <ButtonIcon icon={IconAdd} mode={Mode.light} />
+  </Story>
+  <Story name="ModeDark">
+    <div className="p-5 bg-neutral-700">
+      <ButtonIcon icon={IconAdd} mode={Mode.dark} />
+    </div>
+  </Story>
+</Canvas>
 
 ## Variants
 

--- a/src/components/button/ButtonIcon.tsx
+++ b/src/components/button/ButtonIcon.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import { useTheme } from '../../framework'
-import { Tone } from '../types'
+import { Mode, Tone } from '../types'
 import { ButtonIconCommonProps, ButtonStyleProps, Size, Variant } from './types'
 
 export type ButtonIconProps = React.DetailedHTMLProps<
@@ -14,6 +14,7 @@ export type ButtonIconProps = React.DetailedHTMLProps<
 const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
   (
     {
+      mode = Mode.light,
       variant = Variant.solid,
       size = Size.md,
       tone = Tone.primary,
@@ -33,8 +34,8 @@ const ButtonIcon = React.forwardRef<HTMLButtonElement, ButtonIconProps>(
           button.buttonIcon.base,
           !props.disabled
             ? // @ts-ignore
-              button.variantTone[variant][tone]
-            : button.variantTone[variant].disabled,
+              button.modeVariantTone[mode][variant][tone]
+            : button.modeVariantTone[mode][variant].disabled,
           button.buttonIcon.variantSize.base[size],
           // @ts-ignore
           button.buttonIcon.variantSize[variant]?.[size],

--- a/src/components/button/ButtonIconLink.stories.mdx
+++ b/src/components/button/ButtonIconLink.stories.mdx
@@ -1,7 +1,7 @@
 import IconAdd from '@aboutbits/react-material-icons/dist/IconAdd'
 import IconInfo from '@aboutbits/react-material-icons/dist/IconInfo'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
-import { Tone } from '../types'
+import { Tone, Mode } from '../types'
 import { Size, Variant } from './types'
 import { ButtonIconLink } from './ButtonIconLink'
 
@@ -17,12 +17,17 @@ export const Template = ({ ...args }) => <ButtonIconLink {...args} />
     args={{
       href: '#',
       disabled: false,
+      mode: Mode.light,
       variant: Variant.solid,
       size: Size.md,
       tone: Tone.primary,
       icon: 'Add',
     }}
     argTypes={{
+      mode: {
+        options: Object.values(Mode),
+        control: { type: 'radio' },
+      },
       variant: {
         options: Object.values(Variant),
         control: { type: 'radio' },
@@ -53,6 +58,10 @@ export const Template = ({ ...args }) => <ButtonIconLink {...args} />
 ### Theme
 
 All themes are the same as for the [ButtonIcon](/docs/components-button-buttonicon--default-story#theme).
+
+## Mode
+
+The mode is the same as for the [ButtonIcon](/docs/components-button-buttonicon--default-story#theme).
 
 ## Variants
 

--- a/src/components/button/ButtonIconLink.tsx
+++ b/src/components/button/ButtonIconLink.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React from 'react'
 import { LinkComponentProps, useLinkComponent, useTheme } from '../../framework'
-import { Tone } from '../types'
+import { Mode, Tone } from '../types'
 import {
   ButtonIconCommonProps,
   ButtonStyleProps,
@@ -19,6 +19,7 @@ const ButtonIconLink = React.forwardRef<HTMLAnchorElement, ButtonIconLinkProps>(
   (
     {
       href,
+      mode = Mode.light,
       variant = Variant.solid,
       size = Size.md,
       tone = Tone.primary,
@@ -39,8 +40,8 @@ const ButtonIconLink = React.forwardRef<HTMLAnchorElement, ButtonIconLinkProps>(
       button.buttonIcon.base,
       !disabled
         ? // @ts-ignore
-          button.variantTone[variant][tone]
-        : button.variantTone[variant].disabled,
+          button.modeVariantTone[mode][variant][tone]
+        : button.modeVariantTone[mode][variant].disabled,
       button.buttonIcon.variantSize.base[size],
       // @ts-ignore
       button.buttonIcon.variantSize[variant]?.[size],

--- a/src/components/button/ButtonLink.stories.mdx
+++ b/src/components/button/ButtonLink.stories.mdx
@@ -1,7 +1,7 @@
 import IconAdd from '@aboutbits/react-material-icons/dist/IconAdd'
 import IconInfo from '@aboutbits/react-material-icons/dist/IconInfo'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
-import { Tone } from '../types'
+import { Tone, Mode } from '../types'
 import { Size, Variant } from './types'
 import { ButtonLink } from './ButtonLink'
 
@@ -24,6 +24,7 @@ export const Template = ({ children, ...args }) => (
       href: '#ButtonLink',
       disabled: false,
       internal: true,
+      mode: Mode.light,
       variant: Variant.solid,
       size: Size.md,
       tone: Tone.primary,
@@ -31,6 +32,10 @@ export const Template = ({ children, ...args }) => (
       iconEnd: 'None',
     }}
     argTypes={{
+      mode: {
+        options: Object.values(Mode),
+        control: { type: 'radio' },
+      },
       variant: {
         options: Object.values(Variant),
         control: { type: 'radio' },
@@ -82,6 +87,10 @@ All themes are the same as for the [Button](/docs/components-button-button--defa
     </ButtonLink>
   </Story>
 </Canvas>
+
+## Mode
+
+The mode is the same as for the [Button](/docs/components-button-button--default-story#size).
 
 ## Variants
 

--- a/src/components/button/ButtonLink.tsx
+++ b/src/components/button/ButtonLink.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React from 'react'
 import { useLinkComponent, LinkComponentProps, useTheme } from '../../framework'
-import { Tone } from '../types'
+import { Mode, Tone } from '../types'
 import {
   ButtonCommonProps,
   ButtonStyleProps,
@@ -19,6 +19,7 @@ const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
   (
     {
       href,
+      mode = Mode.light,
       variant = Variant.solid,
       size = Size.md,
       tone = Tone.primary,
@@ -40,8 +41,8 @@ const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       button.button.base,
       !disabled
         ? // @ts-ignore
-          button.variantTone[variant][tone]
-        : button.variantTone[variant].disabled,
+          button.modeVariantTone[mode][variant][tone]
+        : button.modeVariantTone[mode][variant].disabled,
       button.button.variantSize.base[size],
       // @ts-ignore
       button.button.variantSize[variant]?.[size],

--- a/src/components/button/theme.ts
+++ b/src/components/button/theme.ts
@@ -59,51 +59,94 @@ export default {
       },
     },
   },
-  variantTone: {
-    solid: {
-      primary:
-        'bg-primary-500 hover:bg-primary-600 text-white outline-primary-500',
-      neutral:
-        'bg-neutral-700 hover:bg-neutral-900 text-white outline-neutral-800',
-      critical:
-        'bg-critical-500 hover:bg-critical-600 text-white outline-critical-500',
-      warning:
-        'bg-warning-500 hover:bg-warning-600 text-white outline-warning-500',
-      success:
-        'bg-success-600 hover:bg-success-700 text-white outline-success-600',
-      informative:
-        'bg-informative-500 hover:bg-informative-600 text-white outline-informative-500',
-      disabled: 'bg-neutral-200 text-neutral-400',
+  modeVariantTone: {
+    light: {
+      solid: {
+        primary:
+          'bg-primary-500 hover:bg-primary-600 text-white outline-primary-500',
+        neutral:
+          'bg-neutral-700 hover:bg-neutral-900 text-white outline-neutral-800',
+        critical:
+          'bg-critical-500 hover:bg-critical-600 text-white outline-critical-500',
+        warning:
+          'bg-warning-500 hover:bg-warning-600 text-white outline-warning-500',
+        success:
+          'bg-success-600 hover:bg-success-700 text-white outline-success-600',
+        informative:
+          'bg-informative-500 hover:bg-informative-600 text-white outline-informative-500',
+        disabled: 'bg-neutral-200 text-neutral-400',
+      },
+      ghost: {
+        primary:
+          'hover:bg-primary-500/10 focus:bg-primary-500/10 border-primary-500 focus:border-transparent text-primary-500 outline-primary-500',
+        neutral:
+          'hover:bg-neutral-500/10 focus:bg-neutral-500/10 border-neutral-700 focus:border-transparent text-neutral-700 outline-neutral-700',
+        critical:
+          'hover:bg-critical-500/10 focus:bg-critical-500/10 border-critical-500 focus:border-transparent text-critical-500 outline-critical-500',
+        warning:
+          'hover:bg-warning-500/10 focus:bg-warning-500/10 border-warning-600 focus:border-transparent text-warning-600 outline-warning-600',
+        success:
+          'hover:bg-success-500/10 focus:bg-success-500/10 border-success-600 focus:border-transparent text-success-600 outline-success-600',
+        informative:
+          'hover:bg-informative-500/10 focus:bg-informative-500/10 border-informative-500 focus:border-transparent text-informative-500 outline-informative-500',
+        disabled: 'border-neutral-200 text-neutral-400',
+      },
+      transparent: {
+        primary:
+          'hover:bg-primary-500/10 text-primary-500 focus:outline-primary-500',
+        neutral:
+          'hover:bg-neutral-500/10 text-neutral-700 focus:outline-neutral-700',
+        critical:
+          'hover:bg-critical-500/10 text-critical-500 focus:outline-critical-500',
+        warning:
+          'hover:bg-warning-500/10 text-warning-600 focus:outline-warning-600',
+        success:
+          'hover:bg-success-500/10 text-success-600 focus:outline-success-600',
+        informative:
+          'hover:bg-informative-500/10 text-informative-500 focus:outline-informative-500',
+        disabled: 'text-neutral-400',
+      },
     },
-    ghost: {
-      primary:
-        'hover:bg-primary-500/10 focus:bg-primary-500/10 border-primary-500 focus:border-transparent text-primary-500 outline-primary-500',
-      neutral:
-        'hover:bg-neutral-500/10 focus:bg-neutral-500/10 border-neutral-700 focus:border-transparent text-neutral-700 outline-neutral-700',
-      critical:
-        'hover:bg-critical-500/10 focus:bg-critical-500/10 border-critical-500 focus:border-transparent text-critical-500 outline-critical-500',
-      warning:
-        'hover:bg-warning-500/10 focus:bg-warning-500/10 border-warning-600 focus:border-transparent text-warning-600 outline-warning-600',
-      success:
-        'hover:bg-success-500/10 focus:bg-success-500/10 border-success-600 focus:border-transparent text-success-600 outline-success-600',
-      informative:
-        'hover:bg-informative-500/10 focus:bg-informative-500/10 border-informative-500 focus:border-transparent text-informative-500 outline-informative-500',
-      disabled: 'border-neutral-200 text-neutral-400',
-    },
-    transparent: {
-      primary:
-        'hover:bg-primary-500/10 text-primary-500 focus:outline-primary-500',
-      neutral:
-        'hover:bg-neutral-500/10 text-neutral-700 focus:outline-neutral-700',
-      critical:
-        'hover:bg-critical-500/10 text-critical-500 focus:outline-critical-500',
-      warning:
-        'hover:bg-warning-500/10 text-warning-600 focus:outline-warning-600',
-      success:
-        'hover:bg-success-500/10 text-success-600 focus:outline-success-600',
-      informative:
-        'hover:bg-informative-500/10 text-informative-500 focus:outline-informative-500',
-      disabled: 'text-neutral-400',
+    dark: {
+      solid: {
+        primary:
+          'bg-white hover:bg-white/[0.84] text-neutral-900 outline-white',
+        neutral:
+          'bg-white hover:bg-white/[0.84] text-neutral-900 outline-white',
+        critical:
+          'bg-white hover:bg-white/[0.84] text-neutral-900 outline-white',
+        warning:
+          'bg-white hover:bg-white/[0.84] text-neutral-900 outline-white',
+        success:
+          'bg-white hover:bg-white/[0.84] text-neutral-900 outline-white',
+        informative:
+          'bg-white hover:bg-white/[0.84] text-neutral-900 outline-white',
+        disabled: 'bg-white/[0.26] text-white/[0.36]',
+      },
+      ghost: {
+        primary:
+          'hover:bg-white/10 focus:bg-white/10 border-white focus:border-transparent text-white outline-white',
+        neutral:
+          'hover:bg-white/10 focus:bg-white/10 border-white focus:border-transparent text-white outline-white',
+        critical:
+          'hover:bg-white/10 focus:bg-white/10 border-white focus:border-transparent text-white outline-white',
+        warning:
+          'hover:bg-white/10 focus:bg-white/10 border-white focus:border-transparent text-white outline-white',
+        success:
+          'hover:bg-white/10 focus:bg-white/10 border-white focus:border-transparent text-white outline-white',
+        informative:
+          'hover:bg-white/10 focus:bg-white/10 border-white focus:border-transparent text-white outline-white',
+        disabled: 'border-white/[0.36] text-white/[0.36]',
+      },
+      transparent: {
+        primary: 'hover:bg-white/10 text-white focus:outline-white',
+        neutral: 'hover:bg-white/10 text-white focus:outline-white',
+        critical: 'hover:bg-white/10 text-white focus:outline-white',
+        warning: 'hover:bg-white/10 text-white focus:outline-white',
+        success: 'hover:bg-white/10 text-white focus:outline-white',
+        informative: 'hover:bg-white/10 text-white focus:outline-white',
+        disabled: 'text-white/[0.36]',
+      },
     },
   },
 }

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react'
-import { IconProps, Tone } from '../types'
+import { IconProps, ModeProps, Tone } from '../types'
 
 export enum Variant {
   solid = 'solid',
@@ -13,7 +13,7 @@ export enum Size {
   lg = 'lg',
 }
 
-export type ButtonStyleProps = {
+export type ButtonStyleProps = ModeProps & {
   /**
    * Defines the variant of the button.
    **/

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -20,6 +20,9 @@ export enum Tone {
 }
 
 export type ModeProps = {
+  /**
+   * Defines the mode, either light or dark
+   */
   mode?: Mode
 }
 


### PR DESCRIPTION
For now we define the same styles for all tones.

![image](https://user-images.githubusercontent.com/9607491/193235818-58ac8325-33ad-4600-9e2f-9b8aea10a465.png)
