### PR TITLE
Fix `useHandleRequest` on connection error

### DIFF
--- a/src/components/apiHooks/useHandleRequest.ts
+++ b/src/components/apiHooks/useHandleRequest.ts
@@ -26,10 +26,10 @@ export function useHandleRequest<Response>(
       await requestAction()
       onSuccess()
     } catch (error) {
-      const maybeAxiosError = error as AxiosError<ErrorBody>
+      const maybeAxiosError = error as AxiosError<ErrorBody | undefined>
 
-      if (maybeAxiosError?.response?.data.message) {
-        setApiErrorMessage(maybeAxiosError?.response.data.message)
+      if (maybeAxiosError?.response?.data?.message) {
+        setApiErrorMessage(maybeAxiosError.response.data.message)
       } else if (options?.apiFallbackErrorMessage) {
         setApiErrorMessage(options.apiFallbackErrorMessage)
       } else {


### PR DESCRIPTION
If there is no connection or a network error, Axios will not return the expected `ErrorBody`. This results in an JS error, since it's not possible to get `data.message`.