### PR TITLE
Fix tabs scroll on first render

### DIFF
--- a/src/components/tabs/Tab.ts
+++ b/src/components/tabs/Tab.ts
@@ -17,7 +17,7 @@ export type TabProps = {
   active?: boolean
 }
 
-export function useTab<T extends Element>({ name, active }: TabProps) {
+export function useTab<T extends HTMLElement>({ name, active }: TabProps) {
   const { tabs } = useTheme()
   const tabsContext = useContext(TabsContext)
 

--- a/src/components/tabs/theme.ts
+++ b/src/components/tabs/theme.ts
@@ -1,6 +1,6 @@
 export default {
   tabs: {
-    base: 'flex gap-x-3 overflow-x-auto',
+    base: 'relative flex gap-x-3 overflow-x-auto',
   },
   tab: {
     base: 'flex items-center whitespace-nowrap rounded-full fill-current py-2 px-5 font-medium -outline-offset-2 outline-primary-500 focus:outline',

--- a/src/components/utils/useScrollToElementOnFristRender.ts
+++ b/src/components/utils/useScrollToElementOnFristRender.ts
@@ -4,7 +4,7 @@ type Props = {
   active: boolean | null | undefined
 }
 
-export function useScrollToElementOnFirstRender<T extends Element>({
+export function useScrollToElementOnFirstRender<T extends HTMLElement>({
   active,
 }: Props) {
   const elementRef = useRef<T>(null)
@@ -16,7 +16,7 @@ export function useScrollToElementOnFirstRender<T extends Element>({
       const tabList = tab?.parentElement
 
       if (tabList) {
-        tabList.scrollLeft = tab.getBoundingClientRect().left
+        tabList.scrollLeft = tab.offsetLeft
       }
     }
   }, [active])


### PR DESCRIPTION
This fixes the scroll to the active tab on first render. The left position of the active tab was calculated incorrectly and has now been corrected.