### PR TITLE
Make `TabLink` internal by default

### DIFF
--- a/src/components/tabs/TabLink.tsx
+++ b/src/components/tabs/TabLink.tsx
@@ -9,6 +9,7 @@ export function TabLink({
   name,
   active,
   className,
+  internal = true,
   children,
   ...props
 }: TabLinkProps): ReactElement {
@@ -25,6 +26,7 @@ export function TabLink({
       {...props}
       ref={ref}
       className={classNames(tabClassName, className)}
+      internal={internal}
     >
       {children}
     </LinkComponent>


### PR DESCRIPTION
Tabs are usually used to navigate between internal views, therefore it makes sense to flag the links as `internal` by default.