### PR TITLE
Adapt tabs colors (add light bg in normal state)

### DIFF
--- a/src/components/tabs/theme.ts
+++ b/src/components/tabs/theme.ts
@@ -3,8 +3,8 @@ export default {
     base: 'relative flex gap-x-3 overflow-x-auto',
   },
   tab: {
-    base: 'flex items-center whitespace-nowrap rounded-full fill-current py-2 px-5 font-medium -outline-offset-2 outline-primary-500 focus:outline',
-    normal: 'hover:bg-neutral-100',
-    active: 'bg-primary-100',
+    base: 'flex items-center whitespace-nowrap rounded-full py-2 px-5 font-medium outline-1 -outline-offset-1 focus:outline',
+    normal: 'bg-neutral-100 hover:bg-neutral-200 outline-neutral-400',
+    active: 'bg-primary-100 outline-primary-500',
   },
 }


### PR DESCRIPTION
Reference:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/9607491/211757445-42b780f4-f901-4ff8-800b-fbf11f1ccdab.png">

\+ fix ugly outline issue when link is active