### PR TITLE
Improve theme docs by showing parent group in theme json

### DIFF
--- a/.storybook/components/Theme.tsx
+++ b/.storybook/components/Theme.tsx
@@ -10,18 +10,20 @@ export function Theme({
   component: string
   items?: string[]
 }): ReactElement {
-  const theme = items
-    ? Object.fromEntries(
-        // eslint-disable-next-line
-        // @ts-ignore
-        items.map((item) => [item, defaultTheme?.[component]?.[item]])
-      )
-    : defaultTheme?.[component]
+  const theme = {
+    [component]: items
+      ? Object.fromEntries(
+          // eslint-disable-next-line
+          // @ts-ignore
+          items.map((item) => [item, defaultTheme?.[component]?.[item]])
+        )
+      : defaultTheme?.[component],
+  }
 
   return (
     <>
       <Description
-        markdown={`This component uses the following defaults from the \`${component}\` theme:`}
+        markdown={`This component uses the following theme defaults:`}
       />
       <Source code={JSON.stringify(theme, null, 2)} language="json" />
     </>


### PR DESCRIPTION
Instead of just mentioning that input  is part of form  theme, wrap the theme JSON with the corresponding section (in this case form) to make it easier to copy&paste into the `reactui.config.json`

![image](https://user-images.githubusercontent.com/9607491/212088921-608f39bc-ecb9-4d91-b9dd-303194820aae.png)

->

```json
{
  "form": {
    "input": {
      "base": "..."
    }
  }
}
```