### PR TITLE
Allow type-specific form inputs that are validated with zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,12 @@
         "@headlessui/react": "^1.7.7",
         "axios": "^0.27.0 || ^1.1.0",
         "classnames": "^2.0.0",
-        "react-hook-form": "^7.36.1"
+        "react-hook-form": "^7.36.1",
+        "zod": "^3.20.6"
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
-        "@hookform/resolvers": "^2.9.10",
+        "@hookform/resolvers": "^2.9.11",
         "@storybook/addon-essentials": "^6.5.15",
         "@storybook/addon-links": "^6.5.15",
         "@storybook/addon-postcss": "^2.0.0",
@@ -2169,9 +2170,9 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "2.9.10",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.10.tgz",
-      "integrity": "sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==",
+      "version": "2.9.11",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.11.tgz",
+      "integrity": "sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==",
       "dev": true,
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
@@ -30146,6 +30147,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
@@ -31603,9 +31612,9 @@
       }
     },
     "@hookform/resolvers": {
-      "version": "2.9.10",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.10.tgz",
-      "integrity": "sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==",
+      "version": "2.9.11",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.11.tgz",
+      "integrity": "sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -52806,6 +52815,11 @@
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       }
+    },
+    "zod": {
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -44,14 +44,15 @@
     "@headlessui/react": "^1.7.7",
     "axios": "^0.27.0 || ^1.1.0",
     "classnames": "^2.0.0",
-    "react-hook-form": "^7.36.1"
+    "react-hook-form": "^7.36.1",
+    "zod": "^3.20.6"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
-    "@hookform/resolvers": "^2.9.10",
+    "@hookform/resolvers": "^2.9.11",
     "@storybook/addon-essentials": "^6.5.15",
     "@storybook/addon-links": "^6.5.15",
     "@storybook/addon-postcss": "^2.0.0",

--- a/src/components/form/Input.tsx
+++ b/src/components/form/Input.tsx
@@ -42,12 +42,16 @@ function InputComponent(
     className,
     iconStart,
     iconEnd,
+    type,
     ...props
   }: InputProps,
   ref: ForwardedRef<HTMLInputElement>
 ) {
   const { register } = useFormContext()
-  const { ref: fieldRef, ...field } = register(name)
+  const { ref: fieldRef, ...field } = register(name, {
+    valueAsNumber: type === 'number',
+    valueAsDate: type === 'date',
+  })
 
   const forwardedRef = useForwardedRef(ref)
 
@@ -81,6 +85,7 @@ function InputComponent(
             forwardedRef.current = ref
             fieldRef(ref)
           }}
+          type={type}
           {...props}
           {...field}
           disabled={disabled}

--- a/src/examples/form.templates.tsx
+++ b/src/examples/form.templates.tsx
@@ -1,8 +1,8 @@
 import { IndexType } from '@aboutbits/pagination'
-import { yupResolver } from '@hookform/resolvers/yup'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import * as Yup from 'yup'
+import { z } from 'zod'
 import { useHandleFormSubmission } from '../components/apiHooks'
 import { SubmitButton } from '../components/button'
 import {
@@ -37,26 +37,30 @@ import {
   SectionHeader,
 } from '../components/section'
 
-type FormData = {
-  email: string
-  name: {
-    first: string
-    last: string
-  }
-  language: string
-  role: string
-  bio: string
-  favProjectId: string | null
-  serverValidationErrors: boolean
-}
+const formSchema = z.object({
+  username: z.string().min(3),
+  email: z.string().email().min(1),
+  name: z.object({ first: z.string().min(3), last: z.string().min(3) }),
+  age: z.number().min(0),
+  medals: z.number().min(1).nullable(),
+  language: z.string().min(1),
+  role: z.string().min(1),
+  bio: z.string(),
+  favProjectId: z.string().nullable(),
+  serverValidationErrors: z.boolean(),
+})
 
-const defaultValues = {
+type FormData = z.infer<typeof formSchema>
+
+const defaultValues: FormData = {
   username: 'john.doe',
   email: 'john@aboutbits.it',
   name: {
     first: 'John',
     last: 'Doe',
   },
+  age: 25,
+  medals: null,
   language: 'EN',
   role: 'USER',
   bio: 'John is a software engineer from Bolzano, Italy',
@@ -64,29 +68,13 @@ const defaultValues = {
   serverValidationErrors: false,
 }
 
-const resolver = yupResolver(
-  Yup.object().shape({
-    username: Yup.string().required().min(3),
-    email: Yup.string().email().required(),
-    name: Yup.object().shape({
-      first: Yup.string().required().min(3),
-      last: Yup.string().required().min(3),
-    }),
-    language: Yup.string().required(),
-    role: Yup.string().required(),
-    bio: Yup.string(),
-    favProjectId: Yup.string().nullable().required(),
-    serverValidationErrors: Yup.boolean().required(),
-  })
-)
-
 export function FormExampleTemplate({
   onSubmit,
 }: {
   onSubmit: (data: FormData) => void
 }): ReactElement {
   const form = useForm<FormData>({
-    resolver,
+    resolver: zodResolver(formSchema),
     defaultValues,
   })
 
@@ -113,7 +101,6 @@ export function FormExampleTemplate({
             })
             return
           }
-
           onSubmit(data)
           resolve()
         }, 1000)
@@ -165,6 +152,20 @@ export function FormExampleTemplate({
                   />
                 </div>
               </FieldSet>
+              <Input
+                id="age"
+                type="number"
+                name="age"
+                placeholder="Age"
+                label="Age"
+              />
+              <Input
+                id="medals"
+                type="number"
+                name="medals"
+                placeholder="Medals"
+                label="Medals"
+              />
               <Input
                 id="email"
                 type="email"


### PR DESCRIPTION
This PR aims towards the separation of concerns between form input and form validation.

The `Input` component can now receive a type and `react-hook-form` is going to pass to the validator a value with of the chosen type. This relieves the validator from converting data types.

The form's task is to get user input and pass it with a type that is best suited to the application domain (e.g. the age as `number` and not a `string`). The validator's task is to receive data from the form and verify if it is of the expected type. It is not the validator's task to convert data. If the data received from the form is correct, but it is inconvenient for APIs used later on in the application logic, it should be converted by helper functions once those APIs are used. Converting the data sooner than required introduces unnecessary complexities, because the whole application has to work around data that is convenient for the API, but inconvenient for the application.