### PR TITLE
Make `useHandleRequest` return response and make success callback optional

### DIFF
--- a/src/components/apiHooks/__test__/useHandleRequest.test.ts
+++ b/src/components/apiHooks/__test__/useHandleRequest.test.ts
@@ -14,7 +14,11 @@ describe('useHandleRequest', () => {
   const onRequestWithErrorResponse = () =>
     new Promise((resolve, reject) =>
       setTimeout(
-        () => reject({ response: { data: { message: 'Server Error' } } }),
+        () =>
+          reject({
+            isAxiosError: true,
+            response: { data: { message: 'Server Error' } },
+          }),
         100
       )
     )
@@ -29,7 +33,10 @@ describe('useHandleRequest', () => {
     new Promise((resolve, reject) =>
       setTimeout(
         () =>
-          reject({ response: { data: { message: `Server Error for ${id}` } } }),
+          reject({
+            isAxiosError: true,
+            response: { data: { message: `Server Error for ${id}` } },
+          }),
         100
       )
     )
@@ -142,5 +149,26 @@ describe('useHandleRequest', () => {
 
     expect(onRequestResult).toBeUndefined()
     expect(result.current.apiErrorMessage).toBe('Server Error for 1')
+  })
+
+  test('onRequest should throw on error if option is set', async () => {
+    const { result } = renderHook(() =>
+      useHandleRequest(onRequestWithErrorResponse, undefined, {
+        throwOnError: true,
+      })
+    )
+
+    let error = null
+
+    try {
+      await act(() => result.current.onRequest())
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).toEqual({
+      isAxiosError: true,
+      response: { data: { message: 'Server Error' } },
+    })
   })
 })

--- a/src/components/apiHooks/__test__/useHandleRequest.test.ts
+++ b/src/components/apiHooks/__test__/useHandleRequest.test.ts
@@ -1,4 +1,4 @@
-import { waitFor, act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import defaultMessages from '../../../framework/internationalization/defaultMessages.en'
 import { useHandleRequest } from '../useHandleRequest'
 
@@ -6,7 +6,7 @@ describe('useHandleRequest', () => {
   const onRequest = () => new Promise((resolve) => setTimeout(resolve, 100))
 
   const onRequestWithResponse = () =>
-    new Promise((resolve) => setTimeout(() => resolve({ success: true }), 100))
+    new Promise((resolve) => setTimeout(() => resolve({ foo: 'bar' }), 100))
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const onSuccess = () => {}
@@ -23,9 +23,7 @@ describe('useHandleRequest', () => {
     new Promise((resolve, reject) => setTimeout(() => reject(), 100))
 
   const onRequestWithParametersWithSuccess = (id: number) =>
-    new Promise((resolve) =>
-      setTimeout(() => resolve({ id, success: true }), 100)
-    )
+    new Promise((resolve) => setTimeout(() => resolve({ id }), 100))
 
   const onRequestWithParametersWithErrorResponse = (id: number) =>
     new Promise((resolve, reject) =>
@@ -72,7 +70,7 @@ describe('useHandleRequest', () => {
     await act(() => result.current.onRequest())
 
     expect(onSuccess).toHaveBeenCalledTimes(1)
-    expect(onSuccess).toHaveBeenNthCalledWith(1, { success: true })
+    expect(onSuccess).toHaveBeenNthCalledWith(1, { foo: 'bar' })
   })
 
   test('should set apiErrorMessage on error with response', async () => {
@@ -131,7 +129,10 @@ describe('useHandleRequest', () => {
 
     const onRequestResult = await act(() => result.current.onRequest(1))
 
-    expect(onRequestResult).toStrictEqual({ id: 1, success: true })
+    expect(onRequestResult).toStrictEqual({
+      success: true,
+      response: { id: 1 },
+    })
     expect(result.current.apiErrorMessage).toBeNull()
   })
 
@@ -142,7 +143,10 @@ describe('useHandleRequest', () => {
 
     const onRequestResult = await act(() => result.current.onRequest(1))
 
-    expect(onRequestResult).toBeUndefined()
+    expect(onRequestResult).toStrictEqual({
+      success: false,
+      error: { response: { data: { message: 'Server Error for 1' } } },
+    })
     expect(result.current.apiErrorMessage).toBe('Server Error for 1')
   })
 })

--- a/src/components/apiHooks/__test__/useHandleRequest.test.ts
+++ b/src/components/apiHooks/__test__/useHandleRequest.test.ts
@@ -129,10 +129,7 @@ describe('useHandleRequest', () => {
 
     const onRequestResult = await act(() => result.current.onRequest(1))
 
-    expect(onRequestResult).toStrictEqual({
-      success: true,
-      response: { id: 1 },
-    })
+    expect(onRequestResult).toStrictEqual({ id: 1 })
     expect(result.current.apiErrorMessage).toBeNull()
   })
 
@@ -143,10 +140,7 @@ describe('useHandleRequest', () => {
 
     const onRequestResult = await act(() => result.current.onRequest(1))
 
-    expect(onRequestResult).toStrictEqual({
-      success: false,
-      error: { response: { data: { message: 'Server Error for 1' } } },
-    })
+    expect(onRequestResult).toBeUndefined()
     expect(result.current.apiErrorMessage).toBe('Server Error for 1')
   })
 })

--- a/src/components/apiHooks/useHandleRequest.stories.mdx
+++ b/src/components/apiHooks/useHandleRequest.stories.mdx
@@ -21,19 +21,21 @@ npm i axios
 
 ### Parameter
 
-| parameter                         | type                                            | description                                                        |
-| --------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------ |
-| requestAction                     | `(parameters: Parameters) => Promise<Response>` | The function that makes the actual request against the backend.    |
-| onSuccess                         | `(response: Response) => void`                  | The callback function after successful request.                    |
-| options?.apiFallbackErrorMessage? | `string`                                        | Allows you to pass an optional message string for a general error. |
+| parameter                         | type                                             | description                                                        |
+| --------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------ |
+| requestAction                     | `(parameters?: Parameters) => Promise<Response>` | The function that makes the actual request against the backend.    |
+| onSuccess                         | `(response: Response) => void`                   | The callback function after successful request.                    |
+| options?.apiFallbackErrorMessage? | `string`                                         | Allows you to pass an optional message string for a general error. |
+
+_Hint_: If parameters are specified in the `requestAction` function, the `onRequest` function expects the same parameters.
 
 ### Return value
 
-| property        | type                                                                              | description                        |
-| --------------- | --------------------------------------------------------------------------------- | ---------------------------------- |
-| apiErrorMessage | <code>string &#124; null</code>                                                   | Error message of the API request.  |
-| isRequesting    | `boolean`                                                                         | True while the request is pending. |
-| onRequest       | <code>(parameters: Parameters) => Promise&lt;Response &#124; undefined&gt;</code> | Function to fire the request.      |
+| property        | type                                                                               | description                        |
+| --------------- | ---------------------------------------------------------------------------------- | ---------------------------------- |
+| apiErrorMessage | <code>string &#124; null</code>                                                    | Error message of the API request.  |
+| isRequesting    | `boolean`                                                                          | True while the request is pending. |
+| onRequest       | <code>(parameters?: Parameters) => Promise&lt;Response &#124; undefined&gt;</code> | Function to fire the request.      |
 
 ### Internationalization messages
 

--- a/src/components/apiHooks/useHandleRequest.stories.mdx
+++ b/src/components/apiHooks/useHandleRequest.stories.mdx
@@ -29,11 +29,11 @@ npm i axios
 
 ### Return value
 
-| property        | type                                                         | description                        |
-| --------------- | ------------------------------------------------------------ | ---------------------------------- |
-| apiErrorMessage | `string OR null`                                             | Error message of the API request.  |
-| isRequesting    | `boolean`                                                    | True while the request is pending. |
-| onRequest       | `(parameters: Parameters) => Promise<Response OR undefined>` | Function to fire the request.      |
+| property        | type                                                                              | description                        |
+| --------------- | --------------------------------------------------------------------------------- | ---------------------------------- |
+| apiErrorMessage | <code>string &#124; null</code>                                                   | Error message of the API request.  |
+| isRequesting    | `boolean`                                                                         | True while the request is pending. |
+| onRequest       | <code>(parameters: Parameters) => Promise&lt;Response &#124; undefined&gt;</code> | Function to fire the request.      |
 
 ### Internationalization messages
 

--- a/src/components/apiHooks/useHandleRequest.stories.mdx
+++ b/src/components/apiHooks/useHandleRequest.stories.mdx
@@ -9,9 +9,9 @@ import { useHandleRequest } from './useHandleRequest'
 
 # useHandleRequest
 
-The useHandleRequest hook reduces the boilerplate code to handle a request against the backend.
-It takes a function that fires a request, and a success callback function as parameters.
-The hook will then return a function that fires the request and handles the error and intermediate state.
+The `useHandleRequest` hook reduces the boilerplate code to handle a request against the backend.
+It takes a request function and an optional success callback function as parameters.
+The hook returns a function to fire the request and handle the error and intermediate state.
 
 This component expects the following libraries to be installed:
 
@@ -21,19 +21,19 @@ npm i axios
 
 ### Parameter
 
-| parameter                         | type                      | description                                                        |
-| --------------------------------- | ------------------------- | ------------------------------------------------------------------ |
-| requestAction                     | `() => Promise<Response>` | The function that makes the actual request against the backend.    |
-| onSuccess                         | `() => void`              | Callback function after successful request.                        |
-| options?.apiFallbackErrorMessage? | `string`                  | Allows you to pass an optional message string for a general error. |
+| parameter                         | type                                            | description                                                        |
+| --------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------ |
+| requestAction                     | `(parameters: Parameters) => Promise<Response>` | The function that makes the actual request against the backend.    |
+| onSuccess                         | `(response: Response) => void`                  | The callback function after successful request.                    |
+| options?.apiFallbackErrorMessage? | `string`                                        | Allows you to pass an optional message string for a general error. |
 
 ### Return value
 
-| property        | type                  | description                        |
-| --------------- | --------------------- | ---------------------------------- |
-| apiErrorMessage | `string OR null`      | Error message of the API request.  |
-| isRequesting    | `boolean`             | True while the request is pending. |
-| onRequest       | `() => Promise<void>` | Function to fire the request.      |
+| property        | type                                                         | description                        |
+| --------------- | ------------------------------------------------------------ | ---------------------------------- |
+| apiErrorMessage | `string OR null`                                             | Error message of the API request.  |
+| isRequesting    | `boolean`                                                    | True while the request is pending. |
+| onRequest       | `(parameters: Parameters) => Promise<Response OR undefined>` | Function to fire the request.      |
 
 ### Internationalization messages
 
@@ -42,11 +42,11 @@ npm i axios
 ## Usage
 
 ```tsx
-import Axios, { AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
 import { useHandleRequest } from '@aboutbits/react-ui'
 import { ReactElement } from 'react'
 
-const deleteUser = Axios.delete<void, AxiosResponse<void>>(
+const deleteUser = axios.delete<void, AxiosResponse<void>>(
   'http://localhost:8080/users/1'
 )
 
@@ -77,9 +77,9 @@ If you are not sure, whether the backend always returns the error message in an 
 
 ```ts
 import { useHandleRequest } from '@aboutbits/react-ui'
-import Axios, { AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
 
-const deleteUser = Axios.delete<void, AxiosResponse<void>>(
+const deleteUser = axios.delete<void, AxiosResponse<void>>(
   'http://localhost:8080/users/1'
 )
 
@@ -94,4 +94,32 @@ const { apiErrorMessage, isRequesting, onRequest } = useHandleRequest(
     apiFallbackErrorMessage: 'Server error',
   }
 )
+```
+
+### With parameters and without success callback
+
+You can also pass parameters to the request function and omit the success callback.
+
+```ts
+import { useHandleRequest } from '@aboutbits/react-ui'
+import axios, { AxiosResponse } from 'axios'
+
+const validate = (formData: FormData) => {
+  return axios.post<void, AxiosResponse<SuccessResponse>>(
+    'http://localhost:8080/validate-form',
+    formData
+  )
+}
+
+const { apiErrorMessage, isRequesting, onRequest } = useHandleRequest(validate)
+
+// ...
+
+const result = await onRequest(formData)
+
+if (result === undefined) {
+  console.log('Error')
+} else {
+  console.log('Success', result.data) // result is of type AxiosResponse<SuccessResponse>
+}
 ```

--- a/src/components/apiHooks/useHandleRequest.ts
+++ b/src/components/apiHooks/useHandleRequest.ts
@@ -3,10 +3,6 @@ import { useState } from 'react'
 import { useInternationalization } from '../../framework'
 import { ErrorBody } from './types'
 
-export type UseHandleRequestOnRequestReturnType<Response> = Promise<
-  { success: true; response: Response } | { success: false; error: unknown }
->
-
 // Overload for when there are no parameters
 export function useHandleRequest<Response>(
   requestAction: () => Promise<Response>,
@@ -17,7 +13,7 @@ export function useHandleRequest<Response>(
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
-  onRequest: () => UseHandleRequestOnRequestReturnType<Response>
+  onRequest: () => Promise<Response | undefined>
 }
 
 // Overload for when there are parameters
@@ -30,9 +26,7 @@ export function useHandleRequest<Response, Parameters>(
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
-  onRequest: (
-    parameters: Parameters
-  ) => UseHandleRequestOnRequestReturnType<Response>
+  onRequest: (parameters: Parameters) => Promise<Response | undefined>
 }
 
 // Implementation
@@ -45,9 +39,7 @@ export function useHandleRequest<Response, Parameters = undefined>(
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
-  onRequest: (
-    parameters?: Parameters
-  ) => UseHandleRequestOnRequestReturnType<Response>
+  onRequest: (parameters?: Parameters) => Promise<Response | undefined>
 } {
   const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null)
   const { messages } = useInternationalization()
@@ -55,14 +47,12 @@ export function useHandleRequest<Response, Parameters = undefined>(
   const [isRequesting, setIsRequesting] = useState<boolean>(false)
 
   const onRequest = async (parameters?: Parameters) => {
-    let returnValue: Awaited<UseHandleRequestOnRequestReturnType<Response>>
-
     try {
       setApiErrorMessage(null)
       setIsRequesting(true)
       const response = await requestAction(parameters)
       onSuccess?.(response)
-      returnValue = { success: true, response }
+      return response
     } catch (error) {
       const maybeAxiosError = error as AxiosError<ErrorBody | undefined>
 
@@ -73,13 +63,9 @@ export function useHandleRequest<Response, Parameters = undefined>(
       } else {
         setApiErrorMessage(messages['error.api'])
       }
-
-      returnValue = { success: false, error }
     } finally {
       setIsRequesting(false)
     }
-
-    return returnValue
   }
 
   return {

--- a/src/components/apiHooks/useHandleRequest.ts
+++ b/src/components/apiHooks/useHandleRequest.ts
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useInternationalization } from '../../framework'
 import { ErrorBody } from './types'
 
-export type UseHandleRequestReturnType<Response> = Promise<
+export type UseHandleRequestOnRequestReturnType<Response> = Promise<
   { success: true; response: Response } | { success: false; error: unknown }
 >
 
@@ -17,7 +17,7 @@ export function useHandleRequest<Response>(
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
-  onRequest: () => UseHandleRequestReturnType<Response>
+  onRequest: () => UseHandleRequestOnRequestReturnType<Response>
 }
 
 // Overload for when there are parameters
@@ -30,7 +30,9 @@ export function useHandleRequest<Response, Parameters>(
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
-  onRequest: (parameters: Parameters) => UseHandleRequestReturnType<Response>
+  onRequest: (
+    parameters: Parameters
+  ) => UseHandleRequestOnRequestReturnType<Response>
 }
 
 // Implementation
@@ -43,7 +45,9 @@ export function useHandleRequest<Response, Parameters = undefined>(
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
-  onRequest: (parameters?: Parameters) => UseHandleRequestReturnType<Response>
+  onRequest: (
+    parameters?: Parameters
+  ) => UseHandleRequestOnRequestReturnType<Response>
 } {
   const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null)
   const { messages } = useInternationalization()
@@ -51,7 +55,7 @@ export function useHandleRequest<Response, Parameters = undefined>(
   const [isRequesting, setIsRequesting] = useState<boolean>(false)
 
   const onRequest = async (parameters?: Parameters) => {
-    let returnValue: Awaited<UseHandleRequestReturnType<Response>>
+    let returnValue: Awaited<UseHandleRequestOnRequestReturnType<Response>>
 
     try {
       setApiErrorMessage(null)

--- a/src/components/apiHooks/useHandleRequest.ts
+++ b/src/components/apiHooks/useHandleRequest.ts
@@ -1,15 +1,17 @@
-import { AxiosError } from 'axios'
 import { useState } from 'react'
 import { useInternationalization } from '../../framework'
-import { ErrorBody } from './types'
+import { isAxiosErrorWithErrorBody } from './utils'
+
+export type UseHandleRequestOptions = {
+  apiFallbackErrorMessage?: string
+  throwOnError?: boolean
+}
 
 // Overload for when there are no parameters
 export function useHandleRequest<Response>(
   requestAction: () => Promise<Response>,
   onSuccess?: (response: Response) => void,
-  options?: {
-    apiFallbackErrorMessage?: string
-  }
+  options?: UseHandleRequestOptions
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
@@ -20,9 +22,7 @@ export function useHandleRequest<Response>(
 export function useHandleRequest<Response, Parameters>(
   requestAction: (parameters: Parameters) => Promise<Response>,
   onSuccess?: (response: Response) => void,
-  options?: {
-    apiFallbackErrorMessage?: string
-  }
+  options?: UseHandleRequestOptions
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
@@ -33,9 +33,7 @@ export function useHandleRequest<Response, Parameters>(
 export function useHandleRequest<Response, Parameters = undefined>(
   requestAction: (parameters?: Parameters) => Promise<Response>,
   onSuccess?: (response: Response) => void,
-  options?: {
-    apiFallbackErrorMessage?: string
-  }
+  options?: UseHandleRequestOptions
 ): {
   apiErrorMessage: string | null
   isRequesting: boolean
@@ -54,14 +52,16 @@ export function useHandleRequest<Response, Parameters = undefined>(
       onSuccess?.(response)
       return response
     } catch (error) {
-      const maybeAxiosError = error as AxiosError<ErrorBody | undefined>
-
-      if (maybeAxiosError?.response?.data?.message) {
-        setApiErrorMessage(maybeAxiosError.response.data.message)
+      if (isAxiosErrorWithErrorBody(error) && error.response.data.message) {
+        setApiErrorMessage(error.response.data.message)
       } else if (options?.apiFallbackErrorMessage) {
         setApiErrorMessage(options.apiFallbackErrorMessage)
       } else {
         setApiErrorMessage(messages['error.api'])
+      }
+
+      if (options?.throwOnError) {
+        throw error
       }
     } finally {
       setIsRequesting(false)


### PR DESCRIPTION
This is to make `useHandleRequest` more flexible. With this change, the success function will return the response of the request. Also, the success function is optional now.

You can now pass the request parameters to the `onRequest` function, which will also return the response on success, or `undefined` on error.

Additionally, there is a new option `throwOnError`, to let `onRequest` throw the error.

Here's an example (same as in Storybook):

```ts
import { useHandleRequest } from '@aboutbits/react-ui'
import axios, { AxiosResponse } from 'axios'

const validate = (formData: FormData) => {
  return axios.post<void, AxiosResponse<SuccessResponse>>(
    'http://localhost:8080/validate-form',
    formData
  )
}

const { apiErrorMessage, isRequesting, onRequest } = useHandleRequest(validate)

// ...

const result = await onRequest(formData)

if (result === undefined) {
  console.log('Error')
} else {
  console.log('Success', result.data) // result is of type AxiosResponse<SuccessResponse>
}
```