### PR TITLE
Make `useHandleFormSubmission` return response (or error)

### DIFF
--- a/src/components/apiHooks/__test__/useHandleFormSubmission.test.tsx
+++ b/src/components/apiHooks/__test__/useHandleFormSubmission.test.tsx
@@ -191,10 +191,10 @@ describe('useHandleFormSubmission', () => {
 
     const onSubmitResult = await act(() => hookResult.current.onSubmit({}))
 
-    expect(onSubmitResult).toEqual({ success: true, response: { foo: 'bar' } })
+    expect(onSubmitResult).toEqual({ foo: 'bar' })
   })
 
-  test('onSubmit should return the error on error', async () => {
+  test('onSubmit should return nothing on error', async () => {
     const { result: form } = renderHook(() => useForm())
 
     const { result: hookResult } = renderHook(() =>
@@ -205,6 +205,26 @@ describe('useHandleFormSubmission', () => {
 
     const onSubmitResult = await act(() => hookResult.current.onSubmit({}))
 
-    expect(onSubmitResult).toEqual({ success: false, error: axiosError })
+    expect(onSubmitResult).toEqual(undefined)
+  })
+
+  test('onSubmit should throw on error if option is set', async () => {
+    const { result: form } = renderHook(() => useForm())
+
+    const { result: hookResult } = renderHook(() =>
+      useHandleFormSubmission(form.current, onDeleteWithErrorResponse, {
+        throwOnError: true,
+      })
+    )
+
+    let error = null
+
+    try {
+      await act(() => hookResult.current.onSubmit({}))
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).toEqual(axiosError)
   })
 })

--- a/src/components/apiHooks/__test__/useHandleFormSubmission.test.tsx
+++ b/src/components/apiHooks/__test__/useHandleFormSubmission.test.tsx
@@ -14,7 +14,8 @@ const getPromiseState = async (
 }
 
 describe('useHandleFormSubmission', () => {
-  const onMutate = () => new Promise((resolve) => setTimeout(resolve, 500))
+  const onMutate = () =>
+    new Promise((resolve) => setTimeout(() => resolve({ foo: 'bar' }), 500))
 
   const onSuccess = () => undefined
 
@@ -177,5 +178,33 @@ describe('useHandleFormSubmission', () => {
     await act(() => result.current.onSubmit({}))
 
     expect(result.current.apiErrorMessage).toBe(defaultMessages['error.api'])
+  })
+
+  test('onSubmit should return the response on success', async () => {
+    const { result: form } = renderHook(() => useForm())
+
+    const { result: hookResult } = renderHook(() =>
+      useHandleFormSubmission(form.current, onMutate, {
+        onSuccess,
+      })
+    )
+
+    const onSubmitResult = await act(() => hookResult.current.onSubmit({}))
+
+    expect(onSubmitResult).toEqual({ success: true, response: { foo: 'bar' } })
+  })
+
+  test('onSubmit should return the error on error', async () => {
+    const { result: form } = renderHook(() => useForm())
+
+    const { result: hookResult } = renderHook(() =>
+      useHandleFormSubmission(form.current, onDeleteWithErrorResponse, {
+        onSuccess,
+      })
+    )
+
+    const onSubmitResult = await act(() => hookResult.current.onSubmit({}))
+
+    expect(onSubmitResult).toEqual({ success: false, error: axiosError })
   })
 })

--- a/src/components/apiHooks/useHandleFormSubmission.stories.mdx
+++ b/src/components/apiHooks/useHandleFormSubmission.stories.mdx
@@ -9,7 +9,7 @@ import { useHandleFormSubmission } from './useHandleFormSubmission'
 
 # useHandleFormSubmission
 
-The useHandleFormSubmission hook reduces the boilerplate code to handle a `React Hook Form` submission.
+The `useHandleFormSubmission` hook reduces the boilerplate code to handle a `React Hook Form` submission.
 The success callback will be called if the request was successful, otherwise the hook will try to extract validation errors and global errors.
 
 This component expects the following libraries to be installed:
@@ -88,7 +88,7 @@ function UpdateUserForm(): ReactElement {
 
 ### With fallback error message
 
-If you are not sure, whether the backend always returns the error message in an appropriate format, you can define a fallback message id.
+If you are not sure, whether the backend always returns the error message in an appropriate format, you can define a fallback message.
 
 ```ts
 import { useHandleFormSubmission } from '@aboutbits/react-ui'
@@ -121,7 +121,7 @@ const { apiErrorMessage, onSubmit } = useHandleFormSubmission(
 
 ### Validation errors per field
 
-The `useHandleFormSubmission` hook expects an error of the following type to do proper per error handling.
+The `useHandleFormSubmission` hook expects an error of the following type to do proper error handling.
 The `errors` property will be used to extract validation errors per field, whereas the `message` property will be used for global error messages.
 
 ```ts

--- a/src/components/apiHooks/useHandleFormSubmission.stories.mdx
+++ b/src/components/apiHooks/useHandleFormSubmission.stories.mdx
@@ -20,20 +20,23 @@ npm i axios react-hook-form
 
 ### Parameter
 
-| parameter                         | type                                                                   | description                                                       |
-| --------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| form                              | `UseFormReturn<FieldValues>`                                           | The return value of `useForm`                                     |
-| submitAction                      | `() => Promise<Response>`                                              | The function that makes the actual request against the backend.   |
-| options?.onSuccess?               | `(response: Response, values: FieldValues) => void`                    | Callback function after successful request.                       |
-| options?.onError?                 | `(error: AxiosError<ErrorBody> \| Error, values: FieldValues) => void` | Callback function after occurrence of an error.                   |
-| options?.apiFallbackErrorMessage? | `string`                                                               | Allows you to pass an optional message string for a general error |
+| parameter                         | type                                           | description                                                       |
+| --------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
+| form                              | `UseFormReturn<Values>`                        | The return value of `useForm`                                     |
+| submitAction                      | `() => Promise<Response>`                      | The function that makes the actual request against the backend.   |
+| options?.onSuccess?               | `(response: Response, values: Values) => void` | Callback function after successful request.                       |
+| options?.onError?                 | `(error: Error, values: Values) => void`       | Callback function after occurrence of an error.                   |
+| options?.apiFallbackErrorMessage? | `string`                                       | Allows you to pass an optional message string for a general error |
+| options?.throwOnError?            | `boolean`                                      | If set, it will throw the error on failure                        |
+
+Used type generics: `Values extends FieldValues`, `Response`, `Error = unknown`
 
 ### Return value
 
-| property        | type                                                                                                                                                  | description                                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| apiErrorMessage | <code>string &#124; null</code>                                                                                                                       | Error message of the API request.                    |
-| onSubmit        | <code>(values: FieldValues) => Promise&lt;&#123;success: true, response: Response&#125; &#124; &#123;success: false, error: unknown &#125;&gt;</code> | Function to set as the submit function for the form. |
+| property        | type                                                                    | description                                          |
+| --------------- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| apiErrorMessage | <code>string &#124; null</code>                                         | Error message of the API request.                    |
+| onSubmit        | <code>(values: Values) => Promise&lt;Response &#124; unknown&gt;</code> | Function to set as the submit function for the form. |
 
 ### Internationalization messages
 

--- a/src/components/apiHooks/useHandleFormSubmission.stories.mdx
+++ b/src/components/apiHooks/useHandleFormSubmission.stories.mdx
@@ -30,10 +30,10 @@ npm i axios react-hook-form
 
 ### Return value
 
-| property        | type                                     | description                                          |
-| --------------- | ---------------------------------------- | ---------------------------------------------------- |
-| apiErrorMessage | `string OR null`                         | Error message of the API request.                    |
-| onSubmit        | `(values: FieldValues) => Promise<void>` | Function to set as the submit function for the form. |
+| property        | type                                                                                                                                                  | description                                          |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| apiErrorMessage | <code>string &#124; null</code>                                                                                                                       | Error message of the API request.                    |
+| onSubmit        | <code>(values: FieldValues) => Promise&lt;&#123;success: true, response: Response&#125; &#124; &#123;success: false, error: unknown &#125;&gt;</code> | Function to set as the submit function for the form. |
 
 ### Internationalization messages
 

--- a/src/components/apiHooks/useHandleFormSubmission.ts
+++ b/src/components/apiHooks/useHandleFormSubmission.ts
@@ -7,6 +7,7 @@ export type UseHandleFormSubmissionOptions<Values, Response, Error> = {
   onSuccess?: (response: Response, values: Values) => void
   onError?: (error: Error, values: Values) => void
   apiFallbackErrorMessage?: string
+  throwOnError?: boolean
 }
 
 export type UseHandleFormSubmissionOnSubmit<Values, Response> = (
@@ -79,6 +80,10 @@ export function useHandleFormSubmission<
           }
 
           options?.onError?.(error as Error, values)
+
+          if (options?.throwOnError) {
+            throw error as Error
+          }
         }
       },
       [messages, setError, clearErrors, options, submitAction]

--- a/src/components/apiHooks/useHandleFormSubmission.ts
+++ b/src/components/apiHooks/useHandleFormSubmission.ts
@@ -1,13 +1,11 @@
-import { AxiosError } from 'axios'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { FieldValues, Path, UseFormReturn } from 'react-hook-form'
 import { useInternationalization } from '../../framework'
-import { ErrorBody } from './types'
 import { isAxiosErrorWithErrorBody, joinFieldErrorMessages } from './utils'
 
-export type UseHandleFormSubmissionOptions<Values, Response> = {
+export type UseHandleFormSubmissionOptions<Values, Response, Error> = {
   onSuccess?: (response: Response, values: Values) => void
-  onError?: (error: AxiosError<ErrorBody> | Error, values: Values) => void
+  onError?: (error: Error, values: Values) => void
   apiFallbackErrorMessage?: string
 }
 
@@ -15,10 +13,14 @@ export type UseHandleFormSubmissionOnSubmit<Values, Response> = (
   values: Values
 ) => Promise<Response | undefined>
 
-export function useHandleFormSubmission<Values extends FieldValues, Response>(
+export function useHandleFormSubmission<
+  Values extends FieldValues,
+  Response,
+  Error = unknown
+>(
   { setError, clearErrors }: UseFormReturn<Values>,
   submitAction: (body: Values) => Promise<Response>,
-  options?: UseHandleFormSubmissionOptions<Values, Response>
+  options?: UseHandleFormSubmissionOptions<Values, Response, Error>
 ): {
   apiErrorMessage: string | null
   onSubmit: UseHandleFormSubmissionOnSubmit<Values, Response>
@@ -76,7 +78,7 @@ export function useHandleFormSubmission<Values extends FieldValues, Response>(
             })
           }
 
-          options?.onError?.(error as AxiosError<ErrorBody> | Error, values)
+          options?.onError?.(error as Error, values)
         }
       },
       [messages, setError, clearErrors, options, submitAction]

--- a/src/components/apiHooks/utils.ts
+++ b/src/components/apiHooks/utils.ts
@@ -1,3 +1,6 @@
+import axios, { AxiosError } from 'axios'
+import { ErrorBody } from './types'
+
 export function joinFieldErrorMessages(
   errors: Record<string, string[] | null>
 ): Record<string, string> {
@@ -14,4 +17,17 @@ export function joinFieldErrorMessages(
 
     return acc
   }, {})
+}
+
+export function isAxiosErrorWithErrorBody(
+  error: unknown
+): error is Omit<AxiosError<ErrorBody>, 'response'> &
+  Required<Pick<AxiosError<ErrorBody>, 'response'>> {
+  return (
+    // isAxios is not exported in version 0.27
+    // eslint-disable-next-line import/no-named-as-default-member
+    axios.isAxiosError(error) &&
+    typeof error.response?.data === 'object' &&
+    error.response.data !== null
+  )
 }


### PR DESCRIPTION
This makes the `onSubmit` function return the response on success and the error on error.

This PR is related to #188 and should work in the same way as the `onRequest` function of `useHandleRequest`. Eventually, this has to be adjusted after the discussion on the related PR