### PR TITLE
Fix filtering of search results not working on larger screens

### DIFF
--- a/src/examples/list.stories.mdx
+++ b/src/examples/list.stories.mdx
@@ -122,21 +122,6 @@ export const TemplateComplexList = ({
         (filter.role === '' || item.role === filter.role) &&
         (filter.department === '' || item.department === filter.department)
     )
-  const Filter = ({ variant, className }) => (
-    <SectionHeaderGroup className={className}>
-      <Select id="role" name="role" variant={variant}>
-        <Option value="">All roles</Option>
-        <Option value="ADMIN">Admin</Option>
-        <Option value="USER">User</Option>
-      </Select>
-      <Select id="department" name="department" variant={variant}>
-        <Option value="">All departments</Option>
-        <Option value="HR">Human Resources</Option>
-        <Option value="IT">Engineering</Option>
-        <Option value="SALES">Sales</Option>
-      </Select>
-    </SectionHeaderGroup>
-  )
   return (
     <Section>
       <SectionHeaderArea>
@@ -159,14 +144,23 @@ export const TemplateComplexList = ({
               className="flex-col md:flex-row gap-y-2"
             >
               <SectionSearch className="w-full md:w-auto grow" />
-              <Filter
-                variant={InputVariant.transparent}
-                className="hidden md:flex"
-              />
-              <Filter
-                variant={InputVariant.soft}
-                className="grid md:hidden grid-cols-2 w-full"
-              />
+              <SectionHeaderGroup className="grid grid-cols-2 w-full md:block md:flex md:w-auto">
+                <Select id="role" name="role" variant={InputVariant.soft}>
+                  <Option value="">All roles</Option>
+                  <Option value="ADMIN">Admin</Option>
+                  <Option value="USER">User</Option>
+                </Select>
+                <Select
+                  id="department"
+                  name="department"
+                  variant={InputVariant.soft}
+                >
+                  <Option value="">All departments</Option>
+                  <Option value="HR">Human Resources</Option>
+                  <Option value="IT">Engineering</Option>
+                  <Option value="SALES">Sales</Option>
+                </Select>
+              </SectionHeaderGroup>
             </SectionHeaderGroup>
           </SectionHeaderRow>
         </SectionFilter>

--- a/src/examples/list.stories.mdx
+++ b/src/examples/list.stories.mdx
@@ -122,6 +122,10 @@ export const TemplateComplexList = ({
         (filter.role === '' || item.role === filter.role) &&
         (filter.department === '' || item.department === filter.department)
     )
+  const isScreenMedium = useMatchMediaQuery('(min-width: 768px)')
+  const filterVariant = isScreenMedium
+    ? InputVariant.soft
+    : InputVariant.transparent
   return (
     <Section>
       <SectionHeaderArea>
@@ -145,7 +149,7 @@ export const TemplateComplexList = ({
             >
               <SectionSearch className="w-full md:w-auto grow" />
               <SectionHeaderGroup className="grid grid-cols-2 w-full md:block md:flex md:w-auto">
-                <Select id="role" name="role" variant={InputVariant.soft}>
+                <Select id="role" name="role" variant={filterVariant}>
                   <Option value="">All roles</Option>
                   <Option value="ADMIN">Admin</Option>
                   <Option value="USER">User</Option>
@@ -153,7 +157,7 @@ export const TemplateComplexList = ({
                 <Select
                   id="department"
                   name="department"
-                  variant={InputVariant.soft}
+                  variant={filterVariant}
                 >
                   <Option value="">All departments</Option>
                   <Option value="HR">Human Resources</Option>


### PR DESCRIPTION
To apply a different style to the filtering dropdowns based on the screen size, multiple dropdowns have been created and then hidden or shown based on the screen size. Because these dropdowns have the same `name` prop and co-exist in the HTML document, the submission of the dropdown shown on larger screens is overwritten by the submission of the dropdown shown on smaller screens. This causes the filtering to work on smaller screens only!

The solution is to use only one dropdown and to style it based on the screen size using CSS breakpoint queries. The only style that cannot be used in conjunction to CSS breakpoint queries is the `variant` property of the `Select` component. This is a limitation of how the component library has been designed.

We have two options:
- Always keep the same `variant` value for the `Select` component
- Write a hook to determine with JS the screen size and what `variant` value to use