### PR TITLE
Extract `SelectItemInput` from `SelectItem` component

### DIFF
--- a/src/components/form/async/SelectItem.tsx
+++ b/src/components/form/async/SelectItem.tsx
@@ -1,19 +1,13 @@
-import IconClose from '@aboutbits/react-material-icons/dist/IconClose'
-import IconKeyboardArrowDown from '@aboutbits/react-material-icons/dist/IconKeyboardArrowDown'
-import classNames from 'classnames'
-import { ReactElement, ReactNode, useMemo, useRef, useState } from 'react'
+import { ReactElement, ReactNode, useRef, useState } from 'react'
 import { useController } from 'react-hook-form'
-import { useInternationalization, useTheme } from '../../../framework'
 import { DialogProps } from '../../dialog'
-import { ClassNameProps, Mode } from '../../types'
-import { InputError } from '../InputError'
-import { InputLabel } from '../InputLabel'
-import { InputVariant } from '../types'
-import { useCustomInputCss } from '../useCustomInputCss'
+import { ClassNameProps, ModeProps } from '../../types'
+import { VariantProps } from '../types'
 import {
   SelectItemDialogWithSearch,
   SelectItemDialogWithSearchProps,
 } from './SelectItemDialogWithSearch'
+import { SelectItemInput } from './SelectItemInput'
 
 export type SelectItemProps<ItemType, Error> = {
   id: string
@@ -44,7 +38,9 @@ export type SelectItemProps<ItemType, Error> = {
    * @param item
    */
   extractIdFromItem: (item: ItemType) => string
-} & ClassNameProps &
+} & ModeProps &
+  VariantProps &
+  ClassNameProps &
   Pick<
     SelectItemDialogWithSearchProps<ItemType, Error>,
     | 'useGetData'
@@ -54,41 +50,13 @@ export type SelectItemProps<ItemType, Error> = {
     | 'paginationConfig'
   >
 
-/**
- * Converts tailwindcss classes from placeholder to text.
- *
- * Some tailwind classes (e.g. text-left) are excluded from the transformation as they are not linked to the text color.
- **/
-export const replacePlaceholderColorWithTextColor = (css: string): string => {
-  if (!css.includes('placeholder')) {
-    return css
-  }
-  return (
-    css
-      .split(' ')
-      //removes tailwindcss text-<color>
-      .filter((item) =>
-        item.includes('text')
-          ? !!item.match(
-              /:|(text-(left|center|right|justify)|text-opacity-.*)/g
-            )
-          : true
-      )
-      //transforms tailwindcss placeholder:text-* to text-*
-      .map((item) =>
-        item.includes('placeholder:text-')
-          ? item.replace('placeholder:text-', 'text-')
-          : item
-      )
-      .join(' ')
-  )
-}
-
 export function SelectItem<ItemType, Error>({
   disabled = false,
   id,
   name,
   className,
+  mode,
+  variant,
   initialItem,
   renderInputValue,
   label,
@@ -105,97 +73,30 @@ export function SelectItem<ItemType, Error>({
 }: SelectItemProps<ItemType, Error>): ReactElement {
   const { field, fieldState } = useController({ name })
 
-  const componentRef = useRef<HTMLDivElement | null>(null)
   const [showDialog, setShowDialog] = useState<boolean>(false)
   const selectedItem = useRef<ItemType | undefined>(initialItem)
-  const customCss = useCustomInputCss(name, {
-    disabled,
-    mode: Mode.light,
-    variant: InputVariant.ghost,
-  })
-  const customCssEmptyInput = useMemo(
-    () => replacePlaceholderColorWithTextColor(customCss.inputCss),
-    [customCss.inputCss]
-  )
-  const { messages } = useInternationalization()
-  const { form } = useTheme()
-
-  const fieldHasError = !!fieldState.error
 
   return (
     <>
-      <div ref={componentRef} className={className}>
-        <InputLabel inputId={id} label={label} className={customCss.labelCss} />
-        {field.value === '' ? (
-          <button
-            type="button"
-            id={id}
-            onClick={() => {
-              setShowDialog(true)
-            }}
-            className={classNames(
-              customCssEmptyInput,
-              form.selectItem.input.container.base,
-              fieldHasError
-                ? form.selectItem.input.container.error
-                : form.selectItem.input.container.normal
-            )}
-          >
-            <span className={form.selectItem.input.placeholder.base}>
-              {placeholder}
-            </span>
-            <span className={form.selectItem.input.iconContainer.base}>
-              <IconKeyboardArrowDown
-                className={form.selectItem.input.icon.base}
-              />
-            </span>
-          </button>
-        ) : (
-          <div
-            className={classNames(
-              customCss.inputCss,
-              form.selectItem.input.container.base,
-              fieldHasError
-                ? form.selectItem.input.container.error
-                : form.selectItem.input.container.normal
-            )}
-          >
-            <button
-              type="button"
-              id={id}
-              onClick={() => setShowDialog(true)}
-              className={form.selectItem.input.selectButton.base}
-            >
-              <span>
-                {renderInputValue && selectedItem.current
-                  ? renderInputValue(selectedItem.current)
-                  : selectedItem.current && !renderInputValue
-                  ? renderListItem(selectedItem.current)
-                  : field.value}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                field.onChange('')
-                selectedItem.current = undefined
-              }}
-              className={classNames(
-                form.selectItem.input.iconContainer.base,
-                fieldHasError
-                  ? form.selectItem.input.iconContainer.error
-                  : form.selectItem.input.iconContainer.normal
-              )}
-            >
-              <IconClose
-                className={form.selectItem.input.icon.base}
-                title={messages['select.clear']}
-              />
-            </button>
-          </div>
-        )}
-        <InputError name={name} className={customCss.errorCss} />
-      </div>
+      <SelectItemInput
+        id={id}
+        name={name}
+        label={label}
+        placeholder={placeholder}
+        value={field.value}
+        selectedItem={selectedItem.current}
+        hasError={!!fieldState.error}
+        disabled={disabled}
+        mode={mode}
+        variant={variant}
+        className={className}
+        renderInputValue={renderInputValue ? renderInputValue : renderListItem}
+        onOpenSelect={() => setShowDialog(true)}
+        onClear={() => {
+          field.onChange('')
+          selectedItem.current = undefined
+        }}
+      />
       {showDialog && (
         <SelectItemDialogWithSearch
           onDismiss={() => {

--- a/src/components/form/async/SelectItemDialogWithSearch.tsx
+++ b/src/components/form/async/SelectItemDialogWithSearch.tsx
@@ -3,29 +3,28 @@ import { useQueryAndPagination } from '@aboutbits/react-pagination/dist/inMemory
 import { Actions } from '@aboutbits/react-pagination/dist/types'
 import { AsyncView } from '@aboutbits/react-toolbox'
 import { ReactElement, ReactNode } from 'react'
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 import { useInternationalization, useTheme } from '../../../framework'
 import {
   Dialog,
   DialogContentArea,
   DialogContentEmpty,
   DialogContentError,
+  DialogContentList,
+  DialogContentListLoading,
+  DialogFooterWithPaginationInMemory,
   DialogHeaderArea,
   DialogHeaderCloseAction,
+  DialogHeaderRow,
   DialogHeaderTitle,
+  DialogListItemButton,
   DialogPosition,
   DialogProps,
-  DialogContentListLoading,
-  DialogHeaderRow,
-  DialogFooterWithPaginationInMemory,
-  DialogContentList,
-  DialogListItemButton,
 } from '../../dialog'
 import { PaginationInMemoryProps } from '../../pagination'
 import { AutoSubmit } from '../AutoSubmit'
 import { Input } from '../Input'
 import { InputVariant } from '../types'
-import { Form } from '../Form'
 
 type FilterParameters = {
   search: string
@@ -138,15 +137,24 @@ export function SelectItemDialogSearch({
   const form = useForm({ defaultValues })
 
   return (
-    <Form form={form} onSubmit={actions.updateQuery} className="flex-1">
-      <AutoSubmit />
-      <Input
-        name="search"
-        variant={InputVariant.soft}
-        iconStart={IconSearch}
-        placeholder={messages['search.placeholder']}
-      />
-    </Form>
+    <FormProvider {...form}>
+      <form
+        onSubmit={(event) => {
+          // Stop propagation to prevent submitting a form outside of the dialog (bubbling up the React tree)
+          event.stopPropagation()
+          return form.handleSubmit(actions.updateQuery)(event)
+        }}
+        className="flex-1"
+      >
+        <AutoSubmit />
+        <Input
+          name="search"
+          variant={InputVariant.soft}
+          iconStart={IconSearch}
+          placeholder={messages['search.placeholder']}
+        />
+      </form>
+    </FormProvider>
   )
 }
 

--- a/src/components/form/async/SelectItemInput.tsx
+++ b/src/components/form/async/SelectItemInput.tsx
@@ -1,0 +1,128 @@
+import IconClose from '@aboutbits/react-material-icons/dist/IconClose'
+import IconKeyboardArrowDown from '@aboutbits/react-material-icons/dist/IconKeyboardArrowDown'
+import classNames from 'classnames'
+import { ReactNode, useMemo, useRef } from 'react'
+import { useInternationalization, useTheme } from '../../../framework'
+import { Mode } from '../../types'
+import { InputError } from '../InputError'
+import { InputLabel } from '../InputLabel'
+import { InputVariant } from '../types'
+import { useCustomInputCss } from '../useCustomInputCss'
+import { replacePlaceholderColorWithTextColor } from './replacePlaceholderColorWithTextColor'
+
+export type SelectItemInputProps<ItemType> = {
+  id: string
+  name: string
+  label: string
+  placeholder: string
+  disabled?: boolean
+  selectedItem?: ItemType
+  value?: string | number | undefined | null
+  hasError?: boolean
+  renderInputValue?: (item: ItemType) => ReactNode
+  onOpenSelect: () => void
+  onClear: () => void
+  mode?: Mode
+  variant?: InputVariant
+  className?: string
+}
+
+export function SelectItemInput<ItemType>({
+  id,
+  name,
+  label,
+  placeholder,
+  disabled,
+  value,
+  selectedItem,
+  hasError,
+  renderInputValue,
+  onOpenSelect,
+  onClear,
+  mode = Mode.light,
+  variant = InputVariant.ghost,
+  className,
+}: SelectItemInputProps<ItemType>) {
+  const componentRef = useRef<HTMLDivElement | null>(null)
+
+  const customCss = useCustomInputCss(name, {
+    disabled,
+    mode,
+    variant,
+  })
+
+  const customCssEmptyInput = useMemo(
+    () => replacePlaceholderColorWithTextColor(customCss.inputCss),
+    [customCss.inputCss]
+  )
+  const { messages } = useInternationalization()
+  const { form } = useTheme()
+
+  return (
+    <div ref={componentRef} className={className}>
+      <InputLabel inputId={id} label={label} className={customCss.labelCss} />
+      {value === '' ? (
+        <button
+          type="button"
+          id={id}
+          onClick={() => onOpenSelect()}
+          className={classNames(
+            customCssEmptyInput,
+            form.selectItem.input.container.base,
+            hasError
+              ? form.selectItem.input.container.error
+              : form.selectItem.input.container.normal
+          )}
+        >
+          <span className={form.selectItem.input.placeholder.base}>
+            {placeholder}
+          </span>
+          <span className={form.selectItem.input.iconContainer.base}>
+            <IconKeyboardArrowDown
+              className={form.selectItem.input.icon.base}
+            />
+          </span>
+        </button>
+      ) : (
+        <div
+          className={classNames(
+            customCss.inputCss,
+            form.selectItem.input.container.base,
+            hasError
+              ? form.selectItem.input.container.error
+              : form.selectItem.input.container.normal
+          )}
+        >
+          <button
+            type="button"
+            id={id}
+            onClick={() => onOpenSelect()}
+            className={form.selectItem.input.selectButton.base}
+          >
+            <span>
+              {renderInputValue && selectedItem
+                ? renderInputValue(selectedItem)
+                : value}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onClear()}
+            className={classNames(
+              form.selectItem.input.iconContainer.base,
+              hasError
+                ? form.selectItem.input.iconContainer.error
+                : form.selectItem.input.iconContainer.normal
+            )}
+          >
+            <IconClose
+              className={form.selectItem.input.icon.base}
+              title={messages['select.clear']}
+            />
+          </button>
+        </div>
+      )}
+      <InputError name={name} className={customCss.errorCss} />
+    </div>
+  )
+}

--- a/src/components/form/async/__test__/helper.test.ts
+++ b/src/components/form/async/__test__/helper.test.ts
@@ -1,4 +1,4 @@
-import { replacePlaceholderColorWithTextColor } from '../SelectItem'
+import { replacePlaceholderColorWithTextColor } from '../replacePlaceholderColorWithTextColor'
 
 describe('cssClassConverter', () => {
   it('should change nothing, no text-<color> or placeholder:text-<color>', () => {

--- a/src/components/form/async/index.ts
+++ b/src/components/form/async/index.ts
@@ -1,2 +1,4 @@
+export * from './replacePlaceholderColorWithTextColor'
 export * from './SelectItem'
 export * from './SelectItemDialogWithSearch'
+export * from './SelectItemInput'

--- a/src/components/form/async/replacePlaceholderColorWithTextColor.ts
+++ b/src/components/form/async/replacePlaceholderColorWithTextColor.ts
@@ -1,0 +1,29 @@
+/**
+ * Converts TailwindCSS classes from placeholder to text.
+ *
+ * Some Tailwind classes (e.g. text-left) are excluded from the transformation as they are not linked to the text color.
+ **/
+export const replacePlaceholderColorWithTextColor = (css: string): string => {
+  if (!css.includes('placeholder')) {
+    return css
+  }
+  return (
+    css
+      .split(' ')
+      // Removes TailwindCSS text-<color>
+      .filter((item) =>
+        item.includes('text')
+          ? !!item.match(
+              /:|(text-(left|center|right|justify)|text-opacity-.*)/g
+            )
+          : true
+      )
+      // Transforms TailwindCSS placeholder:text-* to text-*
+      .map((item) =>
+        item.includes('placeholder:text-')
+          ? item.replace('placeholder:text-', 'text-')
+          : item
+      )
+      .join(' ')
+  )
+}


### PR DESCRIPTION
This is to reuse the `SelectItemInput` component to make it easier to create a custom `SelectItem` component.
In addition, it exposes the `mode` and `variant` props.

\+ Prevent the `SelectItem` dialog submit from bubbling up the React event tree