### PR TITLE
Fix useHandleFormSubmission

### DIFF
--- a/src/components/apiHooks/index.ts
+++ b/src/components/apiHooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useHandleFormSubmission'
 export * from './useHandleRequest'
 export * from './utils'
+export * from './useIsMounted'

--- a/src/components/apiHooks/useHandleFormSubmission.ts
+++ b/src/components/apiHooks/useHandleFormSubmission.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { FieldValues, Path, UseFormReturn } from 'react-hook-form'
 import { useInternationalization } from '../../framework'
+import { useIsMounted } from './useIsMounted'
 import { isAxiosErrorWithErrorBody, joinFieldErrorMessages } from './utils'
 
 export type UseHandleFormSubmissionOptions<Values, Response, Error> = {
@@ -28,13 +29,7 @@ export function useHandleFormSubmission<
 } {
   const { messages } = useInternationalization()
   const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null)
-  const isMountedRef = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      isMountedRef.current = false
-    }
-  }, [])
+  const isMounted = useIsMounted()
 
   const onSubmit: UseHandleFormSubmissionOnSubmit<Values, Response> =
     useCallback(
@@ -46,7 +41,7 @@ export function useHandleFormSubmission<
           options?.onSuccess?.(response, values)
           return response
         } catch (error) {
-          if (isMountedRef.current) {
+          if (isMounted()) {
             let apiErrorMessage: string | null = null
 
             if (isAxiosErrorWithErrorBody(error)) {
@@ -86,7 +81,7 @@ export function useHandleFormSubmission<
           }
         }
       },
-      [messages, setError, clearErrors, options, submitAction]
+      [messages, setError, clearErrors, options, submitAction, isMounted]
     )
 
   return {

--- a/src/components/apiHooks/useIsMounted.ts
+++ b/src/components/apiHooks/useIsMounted.ts
@@ -1,0 +1,15 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+export function useIsMounted() {
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    isMounted.current = true
+
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  return useCallback(() => isMounted.current, [])
+}


### PR DESCRIPTION
Introduces a new hook `useIsMounted` that checks the mounting state of the calling component correctly. Previously, `useHandleFormSubmission` was not pure and did collect error messages correctly if React's strict mode was enabled in a project.