### PR TITLE
Add possibility of clearing error set by useHandleFormSubmission

### DIFF
--- a/src/components/apiHooks/useHandleFormSubmission.ts
+++ b/src/components/apiHooks/useHandleFormSubmission.ts
@@ -26,17 +26,21 @@ export function useHandleFormSubmission<
 ): {
   apiErrorMessage: string | null
   onSubmit: UseHandleFormSubmissionOnSubmit<Values, Response>
+  clearError: () => void
 } {
   const { messages } = useInternationalization()
   const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null)
+  const clearError = useCallback(() => {
+    clearErrors('apiError' as Path<Values>)
+    setApiErrorMessage(null)
+  }, [clearErrors])
   const isMounted = useIsMounted()
 
   const onSubmit: UseHandleFormSubmissionOnSubmit<Values, Response> =
     useCallback(
       async (values) => {
         try {
-          clearErrors('apiError' as Path<Values>)
-          setApiErrorMessage(null)
+          clearError()
           const response = await submitAction(values)
           options?.onSuccess?.(response, values)
           return response
@@ -81,11 +85,12 @@ export function useHandleFormSubmission<
           }
         }
       },
-      [messages, setError, clearErrors, options, submitAction, isMounted]
+      [messages, setError, clearError, options, submitAction, isMounted]
     )
 
   return {
     apiErrorMessage,
     onSubmit,
+    clearError,
   }
 }

--- a/src/components/apiHooks/useHandleFormSubmission.ts
+++ b/src/components/apiHooks/useHandleFormSubmission.ts
@@ -26,7 +26,7 @@ export function useHandleFormSubmission<
 ): {
   apiErrorMessage: string | null
   onSubmit: UseHandleFormSubmissionOnSubmit<Values, Response>
-  clearError: () => void
+  clearApiErrorMessage: () => void
 } {
   const { messages } = useInternationalization()
   const [apiErrorMessage, setApiErrorMessage] = useState<string | null>(null)
@@ -91,6 +91,6 @@ export function useHandleFormSubmission<
   return {
     apiErrorMessage,
     onSubmit,
-    clearError,
+    clearApiErrorMessage: clearError,
   }
 }


### PR DESCRIPTION
Please tell me if there was already another clean way for clearing the error. I want to no longer show the API error message after the user changed some fields.