### PR TITLE
GitHub-flavoured markdown

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,8 +1,27 @@
 import type { StorybookConfig } from '@storybook/react-vite'
+import remarkGfm from 'remark-gfm'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-links'],
+  addons: [
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        docs: false,
+      },
+    },
+    '@storybook/addon-links',
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        mdxPluginOptions: {
+          mdxCompileOptions: {
+            remarkPlugins: [remarkGfm],
+          },
+        },
+      },
+    },
+  ],
   framework: '@storybook/react-vite',
   staticDirs: ['../public'],
   docs: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-textarea-autosize": "^8.5.2",
+        "remark-gfm": "^3.0.1",
         "rimraf": "^5.0.1",
         "storybook": "^7.0.26",
         "tailwindcss": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-textarea-autosize": "^8.5.2",
+    "remark-gfm": "^3.0.1",
     "rimraf": "^5.0.1",
     "storybook": "^7.0.26",
     "tailwindcss": "^3.2.4",


### PR DESCRIPTION
GitHub-flavoured markdown (GFM) was forgotten during the migration to Storybook v7. This PR enables it to allow features like tables inside markdown stories.