### PR TITLE
Remove check for unused symbols from TypeScript and leave it on ESLint

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
ESLint is more flexible regards unused variables, as it allows us to ignore certain variables, like rest siblings. Therefore it is more convenient to let ESLint check this rule and not TypeScript.