### PR TITLE
Prevent common mistake using DescriptionItem

### DIFF
--- a/src/components/content/DescriptionItem/DescriptionItem.tsx
+++ b/src/components/content/DescriptionItem/DescriptionItem.tsx
@@ -12,12 +12,13 @@ export type DescriptionItemProps = ClassNameProps & {
    * Defines the content of the section description item.
    * Will be placed inside dl.
    **/
-  content: ReactNode
+  content: Exclude<ReactNode, null | undefined>
   /**
    * Defines the title of section description item.
    * Will be placed inside dt.
    **/
-  title: ReactNode
+  title: Exclude<ReactNode, null | undefined>
+
   /**
    * Defines if the component appears or not depending on if the content is empty (null) or not.
    **/
@@ -37,7 +38,7 @@ export function DescriptionItem({
 }: DescriptionItemProps) {
   return (
     <>
-      {((hideIfEmpty && Boolean(content)) || !hideIfEmpty) && (
+      {((hideIfEmpty && content) || !hideIfEmpty) && (
         <DescriptionItemContainer className={className}>
           <DescriptionItemTitle>{title}</DescriptionItemTitle>
           <DescriptionItemContent {...contentProps}>

--- a/src/components/content/DescriptionItem/DescriptionItem.tsx
+++ b/src/components/content/DescriptionItem/DescriptionItem.tsx
@@ -9,40 +9,49 @@ import { DescriptionItemTitle } from './DescriptionItemTitle'
 
 export type DescriptionItemProps = ClassNameProps & {
   /**
-   * Defines the content of the section description item.
-   * Will be placed inside dl.
-   **/
-  content: Exclude<ReactNode, null | undefined>
-  /**
    * Defines the title of section description item.
    * Will be placed inside dt.
    **/
-  title: Exclude<ReactNode, null | undefined>
-
-  /**
-   * Defines if the component appears or not depending on if the content is empty (null) or not.
-   **/
-  hideIfEmpty?: boolean
+  title: ReactNode
   /**
    * Defines the props for the description item content.
    */
   contentProps?: Omit<DescriptionItemContentProps, 'children'>
-}
+} & (
+    | {
+        /**
+         * Defines the content of the section description item.
+         * Will be placed inside dl.
+         **/
+        content: Exclude<ReactNode, null | undefined>
+        hideIfEmpty?: never
+      }
+    | {
+        /**
+         * Defines the content of the section description item.
+         * Will be placed inside dl.
+         **/
+        content: ReactNode
+        /**
+         * Defines if the component appears or not depending on if the content is empty (null) or not.
+         **/
+        hideIfEmpty: true
+      }
+  )
 
 export function DescriptionItem({
   title,
-  content,
   className,
-  hideIfEmpty = false,
   contentProps,
+  ...props
 }: DescriptionItemProps) {
   return (
     <>
-      {((hideIfEmpty && content) || !hideIfEmpty) && (
+      {((props.hideIfEmpty && props.content) || !props.hideIfEmpty) && (
         <DescriptionItemContainer className={className}>
           <DescriptionItemTitle>{title}</DescriptionItemTitle>
           <DescriptionItemContent {...contentProps}>
-            {content}
+            {props.content}
           </DescriptionItemContent>
         </DescriptionItemContainer>
       )}

--- a/src/components/content/DescriptionItem/DescriptionItem.tsx
+++ b/src/components/content/DescriptionItem/DescriptionItem.tsx
@@ -24,7 +24,7 @@ export type DescriptionItemProps = ClassNameProps & {
          * Will be placed inside dl.
          **/
         content: Exclude<ReactNode, null | undefined>
-        hideIfEmpty?: never
+        hideIfEmpty?: false
       }
     | {
         /**


### PR DESCRIPTION
We often times forget to provide a default value for when the content of a `DescriptionItem` is `null` or `undefined`. Changing the props of `DescriptionItem` to not accept `null` or `undefined` would warn us each time we forget to provide a default value like `/` or `-`.