### PR TITLE
Improve back navigation hook

### DIFF
--- a/src/components/header/actions/HeaderBackAction.tsx
+++ b/src/components/header/actions/HeaderBackAction.tsx
@@ -1,5 +1,5 @@
 import IconArrowBack from '@aboutbits/react-material-icons/dist/IconArrowBack'
-import { ComponentProps, ComponentType, ReactElement } from 'react'
+import { ComponentProps, ComponentType } from 'react'
 import { useInternationalization } from '../../../framework'
 import { IconProps } from '../../types'
 import { useBackNavigation } from '../../util/useBackNavigation'
@@ -40,8 +40,8 @@ export function HeaderBackAction({
   onClick,
   fallbackUrl,
   ...props
-}: HeaderBackActionProps): ReactElement {
-  const { goBack } = useBackNavigation()
+}: HeaderBackActionProps) {
+  const { goBack } = useBackNavigation({ fallbackUrl: fallbackUrl ?? '' })
   const { messages } = useInternationalization()
 
   const handleClick: ComponentProps<typeof HeaderLeftActionIcon>['onClick'] = (
@@ -50,7 +50,7 @@ export function HeaderBackAction({
     if (onClick) {
       onClick(event)
     } else {
-      goBack({ fallbackUrl })
+      goBack()
     }
   }
 

--- a/src/components/util/useBackNavigation.ts
+++ b/src/components/util/useBackNavigation.ts
@@ -1,29 +1,26 @@
 import { useCallback } from 'react'
 import { useRouter } from '../../framework'
 
-export const useBackNavigation = () => {
+export const useBackNavigation = ({ fallbackUrl }: { fallbackUrl: string }) => {
   const router = useRouter()
 
   return {
-    goBack: useCallback(
-      ({ fallbackUrl }: { fallbackUrl: string }) => {
-        const canGoBack =
-          typeof window !== 'undefined' &&
-          'navigation' in window &&
-          typeof window.navigation === 'object' &&
-          window.navigation !== null &&
-          'canGoBack' in window.navigation &&
-          typeof window.navigation.canGoBack === 'boolean'
-            ? window.navigation.canGoBack
-            : window.history.length > 1
+    goBack: useCallback(() => {
+      const canGoBack =
+        typeof window !== 'undefined' &&
+        'navigation' in window &&
+        typeof window.navigation === 'object' &&
+        window.navigation !== null &&
+        'canGoBack' in window.navigation &&
+        typeof window.navigation.canGoBack === 'boolean'
+          ? window.navigation.canGoBack
+          : window.history.length > 1
 
-        if (canGoBack) {
-          router.back()
-        } else {
-          router.replace(fallbackUrl)
-        }
-      },
-      [router],
-    ),
+      if (canGoBack) {
+        router.back()
+      } else {
+        router.replace(fallbackUrl)
+      }
+    }, [fallbackUrl, router]),
   }
 }


### PR DESCRIPTION
We usually call the hook `useBackNavigation` to always use the same fallback url. It is cumbersome that the fallback url must be specified each time `goBack` is called. With this PR, the fallback url must be specified only once when calling the hook.

Should one need to use different fallback urls, it is possible to call the hook twice.