### PR TITLE
Update `@aboutbits/pagination` to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@aboutbits/react-ui",
       "version": "2.5.1",
       "dependencies": {
-        "@aboutbits/pagination": "^1.1.0",
+        "@aboutbits/pagination": "^2.0.0",
         "@aboutbits/react-material-icons": "^1.1.2",
         "@aboutbits/react-toolbox": "^0.2.1",
         "@headlessui/react": "^1.7.7",
@@ -144,9 +144,13 @@
       }
     },
     "node_modules/@aboutbits/pagination": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aboutbits/pagination/-/pagination-1.1.0.tgz",
-      "integrity": "sha512-QhnM0c9jOpVxIWGqll2hnTIrrIfBtRsxtcWVKk+ErFG2GCAguRcQ0cNFPHpnJ2NjDp55LpRttOCzrvuDjU14bg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aboutbits/pagination/-/pagination-2.0.0.tgz",
+      "integrity": "sha512-1rBxu2OcKBV9XY4Q9Wji68bwjBn9LhwKePQaFs1qpE3d4lnwOSnwB2xWPNCIfuy5zRdu10idaGLyOks31PLdAQ==",
+      "engines": {
+        "node": "^16",
+        "npm": "^8"
+      }
     },
     "node_modules/@aboutbits/prettier-config": {
       "version": "1.6.0",
@@ -21272,9 +21276,9 @@
       }
     },
     "@aboutbits/pagination": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@aboutbits/pagination/-/pagination-1.1.0.tgz",
-      "integrity": "sha512-QhnM0c9jOpVxIWGqll2hnTIrrIfBtRsxtcWVKk+ErFG2GCAguRcQ0cNFPHpnJ2NjDp55LpRttOCzrvuDjU14bg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aboutbits/pagination/-/pagination-2.0.0.tgz",
+      "integrity": "sha512-1rBxu2OcKBV9XY4Q9Wji68bwjBn9LhwKePQaFs1qpE3d4lnwOSnwB2xWPNCIfuy5zRdu10idaGLyOks31PLdAQ=="
     },
     "@aboutbits/prettier-config": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "@aboutbits/pagination": "^1.1.0",
+    "@aboutbits/pagination": "^2.0.0",
     "@aboutbits/react-material-icons": "^1.1.2",
     "@aboutbits/react-toolbox": "^0.2.1",
     "@headlessui/react": "^1.7.7",


### PR DESCRIPTION
We should update to v2 of the package `pagination`, because it changes the default index type from one-based to zero-based, so that it is equal to the index type of `@aboutbits/react-pagination`.