### PR TITLE
Prefer gap over space for SectionListItemButton and SectionListItemLink

### DIFF
--- a/src/components/section/SectionItem/SectionListItemButton.stories.mdx
+++ b/src/components/section/SectionItem/SectionListItemButton.stories.mdx
@@ -35,7 +35,7 @@ export const Template = ({ children, ...args }) => {
 
 
 
-<Theme component="section" items={['listItemButton']} />
+<Theme component="section" items={['listItemButtonLink']} />
 
 ## Example: Usage within Section
 

--- a/src/components/section/SectionItem/SectionListItemLink.stories.mdx
+++ b/src/components/section/SectionItem/SectionListItemLink.stories.mdx
@@ -32,7 +32,7 @@ export const Template = ({ children, ...args }) => {
 
 
 
-<Theme component="section" items={['listItemLink']} />
+<Theme component="section" items={['listItemButtonLink']} />
 
 ## Example: Usage within Section
 

--- a/src/components/section/theme.ts
+++ b/src/components/section/theme.ts
@@ -39,7 +39,7 @@ export default {
     },
   },
   listItemButtonLink: {
-    base: 'block w-full focus:outline-neutral-800 justify-between space-x-4 hover:bg-neutral-100 active:bg-neutral-100',
+    base: 'w-full focus:outline-neutral-800 justify-between gap-4 hover:bg-neutral-100 active:bg-neutral-100',
     icon: 'fill-current',
   },
   subsectionTitle: {


### PR DESCRIPTION
- fix theme reference of SectionListItem stories
- use gap instead of space utilities for SectionListItemButton and SectionListItemLink
