### PR TITLE
Fix reset of SelectItemFormField

### DIFF
--- a/src/components/react-hook-form/SelectItemFormField/SelectItemFormField.tsx
+++ b/src/components/react-hook-form/SelectItemFormField/SelectItemFormField.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { useController } from 'react-hook-form'
 import { DialogProps } from '../../dialog'
 import { FormVariantProps } from '../../form'
@@ -90,6 +90,14 @@ export function SelectItemFormField<
   const [selectedItem, setSelectedItem] = useState<Item | null>(
     initialItem ?? null,
   )
+
+  useEffect(() => {
+    if (!field.value) {
+      setSelectedItem(null)
+    } else if (initialItem && field.value === extractIdFromItem(initialItem)) {
+      setSelectedItem(initialItem)
+    }
+  }, [field.value, initialItem, extractIdFromItem])
 
   return (
     <>

--- a/src/components/react-hook-form/SelectItemFormField/SelectItemFormField.tsx
+++ b/src/components/react-hook-form/SelectItemFormField/SelectItemFormField.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import { useController } from 'react-hook-form'
 import { DialogProps } from '../../dialog'
 import { FormVariantProps } from '../../form'
@@ -84,6 +84,8 @@ export function SelectItemFormField<
   required,
   hideRequired,
 }: SelectItemFormFieldProps<Item, SelectedItem, ItemId, Error>) {
+  const initialItemRef = useRef(initialItem)
+
   const { field, fieldState } = useController({ name })
 
   const [showDialog, setShowDialog] = useState<boolean>(false)
@@ -94,10 +96,13 @@ export function SelectItemFormField<
   useEffect(() => {
     if (field.value === null || field.value === undefined) {
       setSelectedItem(null)
-    } else if (initialItem && field.value === extractIdFromItem(initialItem)) {
-      setSelectedItem(initialItem)
+    } else if (
+      initialItemRef.current &&
+      field.value === extractIdFromItem(initialItemRef.current)
+    ) {
+      setSelectedItem(initialItemRef.current)
     }
-  }, [field.value, initialItem, extractIdFromItem])
+  }, [field.value, extractIdFromItem])
 
   return (
     <>

--- a/src/components/react-hook-form/SelectItemFormField/SelectItemFormField.tsx
+++ b/src/components/react-hook-form/SelectItemFormField/SelectItemFormField.tsx
@@ -92,7 +92,7 @@ export function SelectItemFormField<
   )
 
   useEffect(() => {
-    if (!field.value) {
+    if (field.value === null || field.value === undefined) {
       setSelectedItem(null)
     } else if (initialItem && field.value === extractIdFromItem(initialItem)) {
       setSelectedItem(initialItem)


### PR DESCRIPTION
Makes the `SelectItemFormField` reset its value when the form is reset with `form.reset()`.