### PR TITLE
Fix keyboard input of date form field

### DIFF
--- a/src/components/react-hook-form/DateFormField.tsx
+++ b/src/components/react-hook-form/DateFormField.tsx
@@ -75,7 +75,7 @@ export const DateFormField = forwardRef(function DateFormField<
 })
 
 export function formatDateForDateInput(date: Date): string {
-  const year = date.getFullYear()
+  const year = `${date.getFullYear()}`.padStart(4, '0')
   const month = `${date.getMonth() + 1}`.padStart(2, '0')
   const day = `${date.getDate()}`.padStart(2, '0')
 


### PR DESCRIPTION
When trying to enter the date with the keyboard, the date reset each time the user started entering the year number. This has been fixed by correctly padding the year number. RIS React UI is not affected by this bug.