### PR TITLE
Fix size of small button icon

### DIFF
--- a/src/components/button/theme.ts
+++ b/src/components/button/theme.ts
@@ -52,7 +52,7 @@ export default {
   buttonIcon: {
     base: 'inline-block rounded-full outline-1 outline-offset-2 focus:outline',
     icon: {
-      base: 'fill-current inline-block align-top',
+      base: 'fill-current inline-block flex items-center',
       size: {
         [Size.Sm]: 'w-5 h-5',
         [Size.Md]: 'w-6 h-6',


### PR DESCRIPTION
The size of a small button icon is now a square like intended and no longer a rectangle.