### PR TITLE
make confirmation-dialog dismissable by keyboard

### DIFF
--- a/src/components/dialog/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/dialog/ConfirmationDialog/ConfirmationDialog.tsx
@@ -68,7 +68,7 @@ export function ConfirmationDialog({
   ...props
 }: ConfirmDialogProps): ReactElement {
   return (
-    <Dialog {...props}>
+    <Dialog {...props} onDismiss={onDismiss}>
       <>
         <DialogHeader title={title} />
         <DialogContent>{body}</DialogContent>


### PR DESCRIPTION
I think it makes sense that a ConfirmationDialog can be dismissed by pressing ESC or by clicking on the dialog overlay.